### PR TITLE
Add octet stream header for download trust store cert

### DIFF
--- a/mqcloudv1/mqcloud_v1.go
+++ b/mqcloudv1/mqcloud_v1.go
@@ -1744,7 +1744,7 @@ func (mqcloud *MqcloudV1) DownloadTrustStoreCertificateWithContext(ctx context.C
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
-	// builder.AddHeader("Accept", "application/octet-stream")
+	builder.AddHeader("Accept", "application/octet-stream")
 	if mqcloud.AcceptLanguage != nil {
 		builder.AddHeader("Accept-Language", fmt.Sprint(*mqcloud.AcceptLanguage))
 	}


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
The header content type was not set to download trust store cert, as the content type octet-stream was not being accepted in the API call. Only json was being accepted.

## What is the new behavior?  
The header content type has now been set to download only trust store cert of type octet-stream.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->