### PR TITLE
Add VPEG support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ dist: focal
 
 
 go:
-- 1.20.x
 - 1.21.x
-
+- 1.22.x
+- 1.23.x
 notifications:
   email: true
 
@@ -19,7 +19,7 @@ before_install:
   - pyenv global 3.8
 
 install:
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.55.2
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.61.0
   - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 script:
@@ -38,5 +38,5 @@ deploy:
     script: npm run semantic-release
     skip_cleanup: true
     on:
-      go: '1.20.x' 
+      go: '1.21.x' 
       branch: main

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Service Name | Package name
 
 * An [IBM Cloud][ibm-cloud-onboarding] account.
 * An IAM API key to allow the SDK to access your account. Create one [here](https://cloud.ibm.com/iam/apikeys).
-* Go version 1.20 or above.
+* Go version 1.21 or above.
 
 ## Installation
 The current version of this SDK: 0.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/mqcloud-go-sdk
 
-go 1.20
+go 1.21
 
 require (
 	github.com/IBM/go-sdk-core/v5 v5.17.2

--- a/mqcloudv1/mqcloud_v1.go
+++ b/mqcloudv1/mqcloud_v1.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.90.0-5aad763d-20240506-203857
+ * IBM OpenAPI SDK Code Generator Version: 3.96.0-d6dec9d7-20241008-212902
  */
 
 // Package mqcloudv1 : Operations and models for the MqcloudV1 service
@@ -38,7 +38,7 @@ import (
 
 // MqcloudV1 : The MQ on Cloud API defines a REST API interface to work with MQ on Cloud service in IBM Cloud.
 //
-// API Version: 1.0.1
+// API Version: 1.1.0
 type MqcloudV1 struct {
 	Service *core.BaseService
 
@@ -2513,8 +2513,321 @@ func (mqcloud *MqcloudV1) SetCertificateAmsChannelsWithContext(ctx context.Conte
 
 	return
 }
+
+// CreateVirtualPrivateEndpointGateway : Create a new virtual private endpoint gateway
+// Create a new virtual private endpoint gateway.
+func (mqcloud *MqcloudV1) CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptions *CreateVirtualPrivateEndpointGatewayOptions) (result *VirtualPrivateEndpointGatewayDetails, response *core.DetailedResponse, err error) {
+	result, response, err = mqcloud.CreateVirtualPrivateEndpointGatewayWithContext(context.Background(), createVirtualPrivateEndpointGatewayOptions)
+	err = core.RepurposeSDKProblem(err, "")
+	return
+}
+
+// CreateVirtualPrivateEndpointGatewayWithContext is an alternate form of the CreateVirtualPrivateEndpointGateway method which supports a Context parameter
+func (mqcloud *MqcloudV1) CreateVirtualPrivateEndpointGatewayWithContext(ctx context.Context, createVirtualPrivateEndpointGatewayOptions *CreateVirtualPrivateEndpointGatewayOptions) (result *VirtualPrivateEndpointGatewayDetails, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createVirtualPrivateEndpointGatewayOptions, "createVirtualPrivateEndpointGatewayOptions cannot be nil")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "unexpected-nil-param", common.GetComponentInfo())
+		return
+	}
+	err = core.ValidateStruct(createVirtualPrivateEndpointGatewayOptions, "createVirtualPrivateEndpointGatewayOptions")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "struct-validation-error", common.GetComponentInfo())
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"service_instance_guid": *createVirtualPrivateEndpointGatewayOptions.ServiceInstanceGuid,
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = mqcloud.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(mqcloud.Service.Options.URL, `/v1/{service_instance_guid}/virtual_private_endpoint_gateway`, pathParamsMap)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "url-resolve-error", common.GetComponentInfo())
+		return
+	}
+
+	for headerName, headerValue := range createVirtualPrivateEndpointGatewayOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("mqcloud", "V1", "CreateVirtualPrivateEndpointGateway")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+	if mqcloud.AcceptLanguage != nil {
+		builder.AddHeader("Accept-Language", fmt.Sprint(*mqcloud.AcceptLanguage))
+	}
+	if createVirtualPrivateEndpointGatewayOptions.TrustedProfile != nil {
+		builder.AddHeader("Trusted-Profile", fmt.Sprint(*createVirtualPrivateEndpointGatewayOptions.TrustedProfile))
+	}
+
+	body := make(map[string]interface{})
+	if createVirtualPrivateEndpointGatewayOptions.Name != nil {
+		body["name"] = createVirtualPrivateEndpointGatewayOptions.Name
+	}
+	if createVirtualPrivateEndpointGatewayOptions.TargetCrn != nil {
+		body["target_crn"] = createVirtualPrivateEndpointGatewayOptions.TargetCrn
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "set-json-body-error", common.GetComponentInfo())
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		err = core.SDKErrorf(err, "", "build-error", common.GetComponentInfo())
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = mqcloud.Service.Request(request, &rawResponse)
+	if err != nil {
+		core.EnrichHTTPProblem(err, "create_virtual_private_endpoint_gateway", getServiceComponentInfo())
+		err = core.SDKErrorf(err, "", "http-request-err", common.GetComponentInfo())
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalVirtualPrivateEndpointGatewayDetails)
+		if err != nil {
+			err = core.SDKErrorf(err, "", "unmarshal-resp-error", common.GetComponentInfo())
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// ListVirtualPrivateEndpointGateways : Get a list of information for all virtual private endpoint gateways
+// Get a list of information for all Virtual private endpoint gateways.
+func (mqcloud *MqcloudV1) ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptions *ListVirtualPrivateEndpointGatewaysOptions) (result *VirtualPrivateEndpointGatewayDetailsCollection, response *core.DetailedResponse, err error) {
+	result, response, err = mqcloud.ListVirtualPrivateEndpointGatewaysWithContext(context.Background(), listVirtualPrivateEndpointGatewaysOptions)
+	err = core.RepurposeSDKProblem(err, "")
+	return
+}
+
+// ListVirtualPrivateEndpointGatewaysWithContext is an alternate form of the ListVirtualPrivateEndpointGateways method which supports a Context parameter
+func (mqcloud *MqcloudV1) ListVirtualPrivateEndpointGatewaysWithContext(ctx context.Context, listVirtualPrivateEndpointGatewaysOptions *ListVirtualPrivateEndpointGatewaysOptions) (result *VirtualPrivateEndpointGatewayDetailsCollection, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(listVirtualPrivateEndpointGatewaysOptions, "listVirtualPrivateEndpointGatewaysOptions cannot be nil")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "unexpected-nil-param", common.GetComponentInfo())
+		return
+	}
+	err = core.ValidateStruct(listVirtualPrivateEndpointGatewaysOptions, "listVirtualPrivateEndpointGatewaysOptions")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "struct-validation-error", common.GetComponentInfo())
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"service_instance_guid": *listVirtualPrivateEndpointGatewaysOptions.ServiceInstanceGuid,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = mqcloud.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(mqcloud.Service.Options.URL, `/v1/{service_instance_guid}/virtual_private_endpoint_gateway`, pathParamsMap)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "url-resolve-error", common.GetComponentInfo())
+		return
+	}
+
+	for headerName, headerValue := range listVirtualPrivateEndpointGatewaysOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("mqcloud", "V1", "ListVirtualPrivateEndpointGateways")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	if mqcloud.AcceptLanguage != nil {
+		builder.AddHeader("Accept-Language", fmt.Sprint(*mqcloud.AcceptLanguage))
+	}
+	if listVirtualPrivateEndpointGatewaysOptions.TrustedProfile != nil {
+		builder.AddHeader("Trusted-Profile", fmt.Sprint(*listVirtualPrivateEndpointGatewaysOptions.TrustedProfile))
+	}
+
+	if listVirtualPrivateEndpointGatewaysOptions.Start != nil {
+		builder.AddQuery("start", fmt.Sprint(*listVirtualPrivateEndpointGatewaysOptions.Start))
+	}
+	if listVirtualPrivateEndpointGatewaysOptions.Limit != nil {
+		builder.AddQuery("limit", fmt.Sprint(*listVirtualPrivateEndpointGatewaysOptions.Limit))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		err = core.SDKErrorf(err, "", "build-error", common.GetComponentInfo())
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = mqcloud.Service.Request(request, &rawResponse)
+	if err != nil {
+		core.EnrichHTTPProblem(err, "list_virtual_private_endpoint_gateways", getServiceComponentInfo())
+		err = core.SDKErrorf(err, "", "http-request-err", common.GetComponentInfo())
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalVirtualPrivateEndpointGatewayDetailsCollection)
+		if err != nil {
+			err = core.SDKErrorf(err, "", "unmarshal-resp-error", common.GetComponentInfo())
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// GetVirtualPrivateEndpointGateway : Display the information for a specific virtual private endpoint gateway
+// Display the information for a specific virtual private endpoint gateway.
+func (mqcloud *MqcloudV1) GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptions *GetVirtualPrivateEndpointGatewayOptions) (result *VirtualPrivateEndpointGatewayDetails, response *core.DetailedResponse, err error) {
+	result, response, err = mqcloud.GetVirtualPrivateEndpointGatewayWithContext(context.Background(), getVirtualPrivateEndpointGatewayOptions)
+	err = core.RepurposeSDKProblem(err, "")
+	return
+}
+
+// GetVirtualPrivateEndpointGatewayWithContext is an alternate form of the GetVirtualPrivateEndpointGateway method which supports a Context parameter
+func (mqcloud *MqcloudV1) GetVirtualPrivateEndpointGatewayWithContext(ctx context.Context, getVirtualPrivateEndpointGatewayOptions *GetVirtualPrivateEndpointGatewayOptions) (result *VirtualPrivateEndpointGatewayDetails, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(getVirtualPrivateEndpointGatewayOptions, "getVirtualPrivateEndpointGatewayOptions cannot be nil")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "unexpected-nil-param", common.GetComponentInfo())
+		return
+	}
+	err = core.ValidateStruct(getVirtualPrivateEndpointGatewayOptions, "getVirtualPrivateEndpointGatewayOptions")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "struct-validation-error", common.GetComponentInfo())
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"service_instance_guid":                 *getVirtualPrivateEndpointGatewayOptions.ServiceInstanceGuid,
+		"virtual_private_endpoint_gateway_guid": *getVirtualPrivateEndpointGatewayOptions.VirtualPrivateEndpointGatewayGuid,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = mqcloud.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(mqcloud.Service.Options.URL, `/v1/{service_instance_guid}/virtual_private_endpoint_gateway/{virtual_private_endpoint_gateway_guid}`, pathParamsMap)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "url-resolve-error", common.GetComponentInfo())
+		return
+	}
+
+	for headerName, headerValue := range getVirtualPrivateEndpointGatewayOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("mqcloud", "V1", "GetVirtualPrivateEndpointGateway")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	if mqcloud.AcceptLanguage != nil {
+		builder.AddHeader("Accept-Language", fmt.Sprint(*mqcloud.AcceptLanguage))
+	}
+	if getVirtualPrivateEndpointGatewayOptions.TrustedProfile != nil {
+		builder.AddHeader("Trusted-Profile", fmt.Sprint(*getVirtualPrivateEndpointGatewayOptions.TrustedProfile))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		err = core.SDKErrorf(err, "", "build-error", common.GetComponentInfo())
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = mqcloud.Service.Request(request, &rawResponse)
+	if err != nil {
+		core.EnrichHTTPProblem(err, "get_virtual_private_endpoint_gateway", getServiceComponentInfo())
+		err = core.SDKErrorf(err, "", "http-request-err", common.GetComponentInfo())
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalVirtualPrivateEndpointGatewayDetails)
+		if err != nil {
+			err = core.SDKErrorf(err, "", "unmarshal-resp-error", common.GetComponentInfo())
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// DeleteVirtualPrivateEndpointGateway : Delete a specific virtual private endpoint gateway
+// Delete a specific virtual_private_endpoint_gateway.
+func (mqcloud *MqcloudV1) DeleteVirtualPrivateEndpointGateway(deleteVirtualPrivateEndpointGatewayOptions *DeleteVirtualPrivateEndpointGatewayOptions) (response *core.DetailedResponse, err error) {
+	response, err = mqcloud.DeleteVirtualPrivateEndpointGatewayWithContext(context.Background(), deleteVirtualPrivateEndpointGatewayOptions)
+	err = core.RepurposeSDKProblem(err, "")
+	return
+}
+
+// DeleteVirtualPrivateEndpointGatewayWithContext is an alternate form of the DeleteVirtualPrivateEndpointGateway method which supports a Context parameter
+func (mqcloud *MqcloudV1) DeleteVirtualPrivateEndpointGatewayWithContext(ctx context.Context, deleteVirtualPrivateEndpointGatewayOptions *DeleteVirtualPrivateEndpointGatewayOptions) (response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(deleteVirtualPrivateEndpointGatewayOptions, "deleteVirtualPrivateEndpointGatewayOptions cannot be nil")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "unexpected-nil-param", common.GetComponentInfo())
+		return
+	}
+	err = core.ValidateStruct(deleteVirtualPrivateEndpointGatewayOptions, "deleteVirtualPrivateEndpointGatewayOptions")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "struct-validation-error", common.GetComponentInfo())
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"service_instance_guid":                 *deleteVirtualPrivateEndpointGatewayOptions.ServiceInstanceGuid,
+		"virtual_private_endpoint_gateway_guid": *deleteVirtualPrivateEndpointGatewayOptions.VirtualPrivateEndpointGatewayGuid,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = mqcloud.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(mqcloud.Service.Options.URL, `/v1/{service_instance_guid}/virtual_private_endpoint_gateway/{virtual_private_endpoint_gateway_guid}`, pathParamsMap)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "url-resolve-error", common.GetComponentInfo())
+		return
+	}
+
+	for headerName, headerValue := range deleteVirtualPrivateEndpointGatewayOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("mqcloud", "V1", "DeleteVirtualPrivateEndpointGateway")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	if mqcloud.AcceptLanguage != nil {
+		builder.AddHeader("Accept-Language", fmt.Sprint(*mqcloud.AcceptLanguage))
+	}
+	if deleteVirtualPrivateEndpointGatewayOptions.TrustedProfile != nil {
+		builder.AddHeader("Trusted-Profile", fmt.Sprint(*deleteVirtualPrivateEndpointGatewayOptions.TrustedProfile))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		err = core.SDKErrorf(err, "", "build-error", common.GetComponentInfo())
+		return
+	}
+
+	response, err = mqcloud.Service.Request(request, nil)
+	if err != nil {
+		core.EnrichHTTPProblem(err, "delete_virtual_private_endpoint_gateway", getServiceComponentInfo())
+		err = core.SDKErrorf(err, "", "http-request-err", common.GetComponentInfo())
+		return
+	}
+
+	return
+}
 func getServiceComponentInfo() *core.ProblemComponent {
-	return core.NewProblemComponent(DefaultServiceName, "1.0.1")
+	return core.NewProblemComponent(DefaultServiceName, "1.1.0")
 }
 
 // ApplicationAPIKeyCreated : A response to creating a new api key, giving the only chance to collect the new apikey.
@@ -2966,7 +3279,7 @@ type CreateApplicationApikeyOptions struct {
 	// The short name of the application api key - conforming to MQ rules.
 	Name *string `json:"name" validate:"required"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3011,7 +3324,7 @@ type CreateApplicationOptions struct {
 	// The name of the application - conforming to MQ rules.
 	Name *string `json:"name" validate:"required"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3055,7 +3368,7 @@ type CreateKeyStorePemCertificateOptions struct {
 	// The filename and path of the certificate to be uploaded.
 	CertificateFile io.ReadCloser `json:"certificate_file" validate:"required"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3119,7 +3432,7 @@ type CreateQueueManagerOptions struct {
 	// The IBM MQ version of the Queue Manager to deploy if not supplied the latest version will be deployed.
 	Version *string `json:"version,omitempty"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3198,7 +3511,7 @@ type CreateTrustStorePemCertificateOptions struct {
 	// The filename and path of the certificate to be uploaded.
 	CertificateFile io.ReadCloser `json:"certificate_file" validate:"required"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3253,7 +3566,7 @@ type CreateUserOptions struct {
 	// The shortname of the user to be created.
 	Name *string `json:"name" validate:"required"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3290,6 +3603,63 @@ func (options *CreateUserOptions) SetHeaders(param map[string]string) *CreateUse
 	return options
 }
 
+// CreateVirtualPrivateEndpointGatewayOptions : The CreateVirtualPrivateEndpointGateway options.
+type CreateVirtualPrivateEndpointGatewayOptions struct {
+	// The GUID that uniquely identifies the MQ on Cloud service instance.
+	ServiceInstanceGuid *string `json:"service_instance_guid" validate:"required,ne="`
+
+	// The name of the virtual private endpoint gateway - conforming to naming rules.
+	Name *string `json:"name" validate:"required"`
+
+	// The CRN of the target reserved capacity service instance.
+	TargetCrn *string `json:"target_crn" validate:"required"`
+
+	// The CRN of the trusted profile to assume for this request.
+	TrustedProfile *string `json:"Trusted-Profile,omitempty"`
+
+	// Allows users to set headers on API requests.
+	Headers map[string]string
+}
+
+// NewCreateVirtualPrivateEndpointGatewayOptions : Instantiate CreateVirtualPrivateEndpointGatewayOptions
+func (*MqcloudV1) NewCreateVirtualPrivateEndpointGatewayOptions(serviceInstanceGuid string, name string, targetCrn string) *CreateVirtualPrivateEndpointGatewayOptions {
+	return &CreateVirtualPrivateEndpointGatewayOptions{
+		ServiceInstanceGuid: core.StringPtr(serviceInstanceGuid),
+		Name:                core.StringPtr(name),
+		TargetCrn:           core.StringPtr(targetCrn),
+	}
+}
+
+// SetServiceInstanceGuid : Allow user to set ServiceInstanceGuid
+func (_options *CreateVirtualPrivateEndpointGatewayOptions) SetServiceInstanceGuid(serviceInstanceGuid string) *CreateVirtualPrivateEndpointGatewayOptions {
+	_options.ServiceInstanceGuid = core.StringPtr(serviceInstanceGuid)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *CreateVirtualPrivateEndpointGatewayOptions) SetName(name string) *CreateVirtualPrivateEndpointGatewayOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetTargetCrn : Allow user to set TargetCrn
+func (_options *CreateVirtualPrivateEndpointGatewayOptions) SetTargetCrn(targetCrn string) *CreateVirtualPrivateEndpointGatewayOptions {
+	_options.TargetCrn = core.StringPtr(targetCrn)
+	return _options
+}
+
+// SetTrustedProfile : Allow user to set TrustedProfile
+func (_options *CreateVirtualPrivateEndpointGatewayOptions) SetTrustedProfile(trustedProfile string) *CreateVirtualPrivateEndpointGatewayOptions {
+	_options.TrustedProfile = core.StringPtr(trustedProfile)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CreateVirtualPrivateEndpointGatewayOptions) SetHeaders(param map[string]string) *CreateVirtualPrivateEndpointGatewayOptions {
+	options.Headers = param
+	return options
+}
+
 // DeleteApplicationOptions : The DeleteApplication options.
 type DeleteApplicationOptions struct {
 	// The GUID that uniquely identifies the MQ on Cloud service instance.
@@ -3298,7 +3668,7 @@ type DeleteApplicationOptions struct {
 	// The id of the application.
 	ApplicationID *string `json:"application_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3339,7 +3709,7 @@ type DeleteKeyStoreCertificateOptions struct {
 	// The id of the certificate.
 	CertificateID *string `json:"certificate_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3384,7 +3754,7 @@ type DeleteQueueManagerOptions struct {
 	// The id of the queue manager to retrieve its full details.
 	QueueManagerID *string `json:"queue_manager_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3425,7 +3795,7 @@ type DeleteTrustStoreCertificateOptions struct {
 	// The id of the certificate.
 	CertificateID *string `json:"certificate_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3470,7 +3840,7 @@ type DeleteUserOptions struct {
 	// The id of the user.
 	UserID *string `json:"user_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3500,6 +3870,53 @@ func (options *DeleteUserOptions) SetHeaders(param map[string]string) *DeleteUse
 	return options
 }
 
+// DeleteVirtualPrivateEndpointGatewayOptions : The DeleteVirtualPrivateEndpointGateway options.
+type DeleteVirtualPrivateEndpointGatewayOptions struct {
+	// The GUID that uniquely identifies the MQ on Cloud service instance.
+	ServiceInstanceGuid *string `json:"service_instance_guid" validate:"required,ne="`
+
+	// The id of the virtual private endpoint gateway.
+	VirtualPrivateEndpointGatewayGuid *string `json:"virtual_private_endpoint_gateway_guid" validate:"required,ne="`
+
+	// The CRN of the trusted profile to assume for this request.
+	TrustedProfile *string `json:"Trusted-Profile,omitempty"`
+
+	// Allows users to set headers on API requests.
+	Headers map[string]string
+}
+
+// NewDeleteVirtualPrivateEndpointGatewayOptions : Instantiate DeleteVirtualPrivateEndpointGatewayOptions
+func (*MqcloudV1) NewDeleteVirtualPrivateEndpointGatewayOptions(serviceInstanceGuid string, virtualPrivateEndpointGatewayGuid string) *DeleteVirtualPrivateEndpointGatewayOptions {
+	return &DeleteVirtualPrivateEndpointGatewayOptions{
+		ServiceInstanceGuid:               core.StringPtr(serviceInstanceGuid),
+		VirtualPrivateEndpointGatewayGuid: core.StringPtr(virtualPrivateEndpointGatewayGuid),
+	}
+}
+
+// SetServiceInstanceGuid : Allow user to set ServiceInstanceGuid
+func (_options *DeleteVirtualPrivateEndpointGatewayOptions) SetServiceInstanceGuid(serviceInstanceGuid string) *DeleteVirtualPrivateEndpointGatewayOptions {
+	_options.ServiceInstanceGuid = core.StringPtr(serviceInstanceGuid)
+	return _options
+}
+
+// SetVirtualPrivateEndpointGatewayGuid : Allow user to set VirtualPrivateEndpointGatewayGuid
+func (_options *DeleteVirtualPrivateEndpointGatewayOptions) SetVirtualPrivateEndpointGatewayGuid(virtualPrivateEndpointGatewayGuid string) *DeleteVirtualPrivateEndpointGatewayOptions {
+	_options.VirtualPrivateEndpointGatewayGuid = core.StringPtr(virtualPrivateEndpointGatewayGuid)
+	return _options
+}
+
+// SetTrustedProfile : Allow user to set TrustedProfile
+func (_options *DeleteVirtualPrivateEndpointGatewayOptions) SetTrustedProfile(trustedProfile string) *DeleteVirtualPrivateEndpointGatewayOptions {
+	_options.TrustedProfile = core.StringPtr(trustedProfile)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DeleteVirtualPrivateEndpointGatewayOptions) SetHeaders(param map[string]string) *DeleteVirtualPrivateEndpointGatewayOptions {
+	options.Headers = param
+	return options
+}
+
 // DownloadKeyStoreCertificateOptions : The DownloadKeyStoreCertificate options.
 type DownloadKeyStoreCertificateOptions struct {
 	// The GUID that uniquely identifies the MQ on Cloud service instance.
@@ -3511,7 +3928,7 @@ type DownloadKeyStoreCertificateOptions struct {
 	// The id of the certificate.
 	CertificateID *string `json:"certificate_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3559,7 +3976,7 @@ type DownloadTrustStoreCertificateOptions struct {
 	// The id of the certificate.
 	CertificateID *string `json:"certificate_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3622,7 +4039,7 @@ type GetApplicationOptions struct {
 	// The id of the application.
 	ApplicationID *string `json:"application_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3663,7 +4080,7 @@ type GetCertificateAmsChannelsOptions struct {
 	// The GUID that uniquely identifies the MQ on Cloud service instance.
 	ServiceInstanceGuid *string `json:"service_instance_guid" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3711,7 +4128,7 @@ type GetKeyStoreCertificateOptions struct {
 	// The id of the certificate.
 	CertificateID *string `json:"certificate_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3753,7 +4170,7 @@ type GetOptionsOptions struct {
 	// The GUID that uniquely identifies the MQ on Cloud service instance.
 	ServiceInstanceGuid *string `json:"service_instance_guid" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3784,7 +4201,7 @@ type GetQueueManagerAvailableUpgradeVersionsOptions struct {
 	// The id of the queue manager to retrieve its full details.
 	QueueManagerID *string `json:"queue_manager_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3822,7 +4239,7 @@ type GetQueueManagerConnectionInfoOptions struct {
 	// The id of the queue manager to retrieve its full details.
 	QueueManagerID *string `json:"queue_manager_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3860,7 +4277,7 @@ type GetQueueManagerOptions struct {
 	// The id of the queue manager to retrieve its full details.
 	QueueManagerID *string `json:"queue_manager_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3898,7 +4315,7 @@ type GetQueueManagerStatusOptions struct {
 	// The id of the queue manager to retrieve its full details.
 	QueueManagerID *string `json:"queue_manager_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3939,7 +4356,7 @@ type GetTrustStoreCertificateOptions struct {
 	// The id of the certificate.
 	CertificateID *string `json:"certificate_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -3981,7 +4398,7 @@ type GetUsageDetailsOptions struct {
 	// The GUID that uniquely identifies the MQ on Cloud service instance.
 	ServiceInstanceGuid *string `json:"service_instance_guid" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -4012,7 +4429,7 @@ type GetUserOptions struct {
 	// The id of the user.
 	UserID *string `json:"user_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -4038,6 +4455,53 @@ func (_options *GetUserOptions) SetUserID(userID string) *GetUserOptions {
 
 // SetHeaders : Allow user to set Headers
 func (options *GetUserOptions) SetHeaders(param map[string]string) *GetUserOptions {
+	options.Headers = param
+	return options
+}
+
+// GetVirtualPrivateEndpointGatewayOptions : The GetVirtualPrivateEndpointGateway options.
+type GetVirtualPrivateEndpointGatewayOptions struct {
+	// The GUID that uniquely identifies the MQ on Cloud service instance.
+	ServiceInstanceGuid *string `json:"service_instance_guid" validate:"required,ne="`
+
+	// The id of the virtual private endpoint gateway.
+	VirtualPrivateEndpointGatewayGuid *string `json:"virtual_private_endpoint_gateway_guid" validate:"required,ne="`
+
+	// The CRN of the trusted profile to assume for this request.
+	TrustedProfile *string `json:"Trusted-Profile,omitempty"`
+
+	// Allows users to set headers on API requests.
+	Headers map[string]string
+}
+
+// NewGetVirtualPrivateEndpointGatewayOptions : Instantiate GetVirtualPrivateEndpointGatewayOptions
+func (*MqcloudV1) NewGetVirtualPrivateEndpointGatewayOptions(serviceInstanceGuid string, virtualPrivateEndpointGatewayGuid string) *GetVirtualPrivateEndpointGatewayOptions {
+	return &GetVirtualPrivateEndpointGatewayOptions{
+		ServiceInstanceGuid:               core.StringPtr(serviceInstanceGuid),
+		VirtualPrivateEndpointGatewayGuid: core.StringPtr(virtualPrivateEndpointGatewayGuid),
+	}
+}
+
+// SetServiceInstanceGuid : Allow user to set ServiceInstanceGuid
+func (_options *GetVirtualPrivateEndpointGatewayOptions) SetServiceInstanceGuid(serviceInstanceGuid string) *GetVirtualPrivateEndpointGatewayOptions {
+	_options.ServiceInstanceGuid = core.StringPtr(serviceInstanceGuid)
+	return _options
+}
+
+// SetVirtualPrivateEndpointGatewayGuid : Allow user to set VirtualPrivateEndpointGatewayGuid
+func (_options *GetVirtualPrivateEndpointGatewayOptions) SetVirtualPrivateEndpointGatewayGuid(virtualPrivateEndpointGatewayGuid string) *GetVirtualPrivateEndpointGatewayOptions {
+	_options.VirtualPrivateEndpointGatewayGuid = core.StringPtr(virtualPrivateEndpointGatewayGuid)
+	return _options
+}
+
+// SetTrustedProfile : Allow user to set TrustedProfile
+func (_options *GetVirtualPrivateEndpointGatewayOptions) SetTrustedProfile(trustedProfile string) *GetVirtualPrivateEndpointGatewayOptions {
+	_options.TrustedProfile = core.StringPtr(trustedProfile)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetVirtualPrivateEndpointGatewayOptions) SetHeaders(param map[string]string) *GetVirtualPrivateEndpointGatewayOptions {
 	options.Headers = param
 	return options
 }
@@ -4215,7 +4679,7 @@ type ListApplicationsOptions struct {
 	// The numbers of resources to return.
 	Limit *int64 `json:"limit,omitempty"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -4258,7 +4722,7 @@ type ListKeyStoreCertificatesOptions struct {
 	// The id of the queue manager to retrieve its full details.
 	QueueManagerID *string `json:"queue_manager_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -4299,7 +4763,7 @@ type ListQueueManagersOptions struct {
 	// The numbers of resources to return.
 	Limit *int64 `json:"limit,omitempty"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -4342,7 +4806,7 @@ type ListTrustStoreCertificatesOptions struct {
 	// The id of the queue manager to retrieve its full details.
 	QueueManagerID *string `json:"queue_manager_id" validate:"required,ne="`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -4383,7 +4847,7 @@ type ListUsersOptions struct {
 	// The numbers of resources to return.
 	Limit *int64 `json:"limit,omitempty"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -4414,6 +4878,61 @@ func (_options *ListUsersOptions) SetLimit(limit int64) *ListUsersOptions {
 
 // SetHeaders : Allow user to set Headers
 func (options *ListUsersOptions) SetHeaders(param map[string]string) *ListUsersOptions {
+	options.Headers = param
+	return options
+}
+
+// ListVirtualPrivateEndpointGatewaysOptions : The ListVirtualPrivateEndpointGateways options.
+type ListVirtualPrivateEndpointGatewaysOptions struct {
+	// The GUID that uniquely identifies the MQ on Cloud service instance.
+	ServiceInstanceGuid *string `json:"service_instance_guid" validate:"required,ne="`
+
+	// The CRN of the trusted profile to assume for this request.
+	TrustedProfile *string `json:"Trusted-Profile,omitempty"`
+
+	// A server-provided token determining what resource to start the page on.
+	Start *string `json:"start,omitempty"`
+
+	// The numbers of resources to return.
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Allows users to set headers on API requests.
+	Headers map[string]string
+}
+
+// NewListVirtualPrivateEndpointGatewaysOptions : Instantiate ListVirtualPrivateEndpointGatewaysOptions
+func (*MqcloudV1) NewListVirtualPrivateEndpointGatewaysOptions(serviceInstanceGuid string) *ListVirtualPrivateEndpointGatewaysOptions {
+	return &ListVirtualPrivateEndpointGatewaysOptions{
+		ServiceInstanceGuid: core.StringPtr(serviceInstanceGuid),
+	}
+}
+
+// SetServiceInstanceGuid : Allow user to set ServiceInstanceGuid
+func (_options *ListVirtualPrivateEndpointGatewaysOptions) SetServiceInstanceGuid(serviceInstanceGuid string) *ListVirtualPrivateEndpointGatewaysOptions {
+	_options.ServiceInstanceGuid = core.StringPtr(serviceInstanceGuid)
+	return _options
+}
+
+// SetTrustedProfile : Allow user to set TrustedProfile
+func (_options *ListVirtualPrivateEndpointGatewaysOptions) SetTrustedProfile(trustedProfile string) *ListVirtualPrivateEndpointGatewaysOptions {
+	_options.TrustedProfile = core.StringPtr(trustedProfile)
+	return _options
+}
+
+// SetStart : Allow user to set Start
+func (_options *ListVirtualPrivateEndpointGatewaysOptions) SetStart(start string) *ListVirtualPrivateEndpointGatewaysOptions {
+	_options.Start = core.StringPtr(start)
+	return _options
+}
+
+// SetLimit : Allow user to set Limit
+func (_options *ListVirtualPrivateEndpointGatewaysOptions) SetLimit(limit int64) *ListVirtualPrivateEndpointGatewaysOptions {
+	_options.Limit = core.Int64Ptr(limit)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *ListVirtualPrivateEndpointGatewaysOptions) SetHeaders(param map[string]string) *ListVirtualPrivateEndpointGatewaysOptions {
 	options.Headers = param
 	return options
 }
@@ -4821,7 +5340,7 @@ type SetCertificateAmsChannelsOptions struct {
 	// Strategy for how the supplied channels should be applied.
 	UpdateStrategy *string `json:"update_strategy,omitempty"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -4889,7 +5408,7 @@ type SetQueueManagerVersionOptions struct {
 	// The version upgrade to apply to the queue manager.
 	Version *string `json:"version" validate:"required"`
 
-	// Allows users to set headers on API requests
+	// Allows users to set headers on API requests.
 	Headers map[string]string
 }
 
@@ -5230,6 +5749,113 @@ func (resp *UserDetailsCollection) GetNextOffset() (*int64, error) {
 	return core.Int64Ptr(offsetValue), nil
 }
 
+// VirtualPrivateEndpointGatewayDetails : The details of a specific Virtual Private Endpoint Gateway.
+type VirtualPrivateEndpointGatewayDetails struct {
+	// URL for the details of the virtual private endpoint gateway.
+	Href *string `json:"href" validate:"required"`
+
+	// The ID of the virtual private endpoint gateway which was allocated on creation.
+	ID *string `json:"id" validate:"required"`
+
+	// The name of the virtual private endpoint gateway, created by the user.
+	Name *string `json:"name" validate:"required"`
+
+	// The CRN of the virtual private endpoint gateway the user is trying to connect to.
+	TargetCrn *string `json:"target_crn" validate:"required"`
+
+	// The lifecycle state of this virtual privage endpoint.
+	Status *string `json:"status" validate:"required"`
+}
+
+// UnmarshalVirtualPrivateEndpointGatewayDetails unmarshals an instance of VirtualPrivateEndpointGatewayDetails from the specified map of raw messages.
+func UnmarshalVirtualPrivateEndpointGatewayDetails(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(VirtualPrivateEndpointGatewayDetails)
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "href-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "id-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "name-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "target_crn", &obj.TargetCrn)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "target_crn-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "status", &obj.Status)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "status-error", common.GetComponentInfo())
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// VirtualPrivateEndpointGatewayDetailsCollection : A list of virtual private endpoint gateway summaries.
+type VirtualPrivateEndpointGatewayDetailsCollection struct {
+	// Results per page, same for all collections.
+	Limit *int64 `json:"limit" validate:"required"`
+
+	// Link to first page of results.
+	First *First `json:"first" validate:"required"`
+
+	// Link to next page of results.
+	Next *Next `json:"next,omitempty"`
+
+	// List of virtual private endpoint gateways.
+	VirtualPrivateEndpointGateways []VirtualPrivateEndpointGatewayDetails `json:"virtual_private_endpoint_gateways" validate:"required"`
+}
+
+// UnmarshalVirtualPrivateEndpointGatewayDetailsCollection unmarshals an instance of VirtualPrivateEndpointGatewayDetailsCollection from the specified map of raw messages.
+func UnmarshalVirtualPrivateEndpointGatewayDetailsCollection(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(VirtualPrivateEndpointGatewayDetailsCollection)
+	err = core.UnmarshalPrimitive(m, "limit", &obj.Limit)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "limit-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalModel(m, "first", &obj.First, UnmarshalFirst)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "first-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalModel(m, "next", &obj.Next, UnmarshalNext)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "next-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalModel(m, "virtual_private_endpoint_gateways", &obj.VirtualPrivateEndpointGateways, UnmarshalVirtualPrivateEndpointGatewayDetails)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "virtual_private_endpoint_gateways-error", common.GetComponentInfo())
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// Retrieve the value to be passed to a request to access the next page of results
+func (resp *VirtualPrivateEndpointGatewayDetailsCollection) GetNextStart() (*string, error) {
+	if core.IsNil(resp.Next) {
+		return nil, nil
+	}
+	start, err := core.GetQueryParam(resp.Next.Href, "start")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "read-query-param-error", common.GetComponentInfo())
+		return nil, err
+	} else if start == nil {
+		return nil, nil
+	}
+	return start, nil
+}
+
 // QueueManagersPager can be used to simplify the use of the "ListQueueManagers" method.
 type QueueManagersPager struct {
 	hasNext     bool
@@ -5501,6 +6127,98 @@ func (pager *ApplicationsPager) GetNext() (page []ApplicationDetails, err error)
 
 // GetAll invokes GetAllWithContext() using context.Background() as the Context parameter.
 func (pager *ApplicationsPager) GetAll() (allItems []ApplicationDetails, err error) {
+	allItems, err = pager.GetAllWithContext(context.Background())
+	err = core.RepurposeSDKProblem(err, "")
+	return
+}
+
+// VirtualPrivateEndpointGatewaysPager can be used to simplify the use of the "ListVirtualPrivateEndpointGateways" method.
+type VirtualPrivateEndpointGatewaysPager struct {
+	hasNext     bool
+	options     *ListVirtualPrivateEndpointGatewaysOptions
+	client      *MqcloudV1
+	pageContext struct {
+		next *string
+	}
+}
+
+// NewVirtualPrivateEndpointGatewaysPager returns a new VirtualPrivateEndpointGatewaysPager instance.
+func (mqcloud *MqcloudV1) NewVirtualPrivateEndpointGatewaysPager(options *ListVirtualPrivateEndpointGatewaysOptions) (pager *VirtualPrivateEndpointGatewaysPager, err error) {
+	if options.Start != nil && *options.Start != "" {
+		err = core.SDKErrorf(nil, "the 'options.Start' field should not be set", "no-query-setting", common.GetComponentInfo())
+		return
+	}
+
+	var optionsCopy ListVirtualPrivateEndpointGatewaysOptions = *options
+	pager = &VirtualPrivateEndpointGatewaysPager{
+		hasNext: true,
+		options: &optionsCopy,
+		client:  mqcloud,
+	}
+	return
+}
+
+// HasNext returns true if there are potentially more results to be retrieved.
+func (pager *VirtualPrivateEndpointGatewaysPager) HasNext() bool {
+	return pager.hasNext
+}
+
+// GetNextWithContext returns the next page of results using the specified Context.
+func (pager *VirtualPrivateEndpointGatewaysPager) GetNextWithContext(ctx context.Context) (page []VirtualPrivateEndpointGatewayDetails, err error) {
+	if !pager.HasNext() {
+		return nil, fmt.Errorf("no more results available")
+	}
+
+	pager.options.Start = pager.pageContext.next
+
+	result, _, err := pager.client.ListVirtualPrivateEndpointGatewaysWithContext(ctx, pager.options)
+	if err != nil {
+		err = core.RepurposeSDKProblem(err, "error-getting-next-page")
+		return
+	}
+
+	var next *string
+	if result.Next != nil {
+		var start *string
+		start, err = core.GetQueryParam(result.Next.Href, "start")
+		if err != nil {
+			errMsg := fmt.Sprintf("error retrieving 'start' query parameter from URL '%s': %s", *result.Next.Href, err.Error())
+			err = core.SDKErrorf(err, errMsg, "get-query-error", common.GetComponentInfo())
+			return
+		}
+		next = start
+	}
+	pager.pageContext.next = next
+	pager.hasNext = (pager.pageContext.next != nil)
+	page = result.VirtualPrivateEndpointGateways
+
+	return
+}
+
+// GetAllWithContext returns all results by invoking GetNextWithContext() repeatedly
+// until all pages of results have been retrieved.
+func (pager *VirtualPrivateEndpointGatewaysPager) GetAllWithContext(ctx context.Context) (allItems []VirtualPrivateEndpointGatewayDetails, err error) {
+	for pager.HasNext() {
+		var nextPage []VirtualPrivateEndpointGatewayDetails
+		nextPage, err = pager.GetNextWithContext(ctx)
+		if err != nil {
+			err = core.RepurposeSDKProblem(err, "error-getting-next-page")
+			return
+		}
+		allItems = append(allItems, nextPage...)
+	}
+	return
+}
+
+// GetNext invokes GetNextWithContext() using context.Background() as the Context parameter.
+func (pager *VirtualPrivateEndpointGatewaysPager) GetNext() (page []VirtualPrivateEndpointGatewayDetails, err error) {
+	page, err = pager.GetNextWithContext(context.Background())
+	err = core.RepurposeSDKProblem(err, "")
+	return
+}
+
+// GetAll invokes GetAllWithContext() using context.Background() as the Context parameter.
+func (pager *VirtualPrivateEndpointGatewaysPager) GetAll() (allItems []VirtualPrivateEndpointGatewayDetails, err error) {
 	allItems, err = pager.GetAllWithContext(context.Background())
 	err = core.RepurposeSDKProblem(err, "")
 	return

--- a/mqcloudv1/mqcloud_v1_examples_test.go
+++ b/mqcloudv1/mqcloud_v1_examples_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/mqcloud-go-sdk/mqcloudv1"
@@ -106,7 +107,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_usage_details
 
 			getUsageDetailsOptions := mqcloudService.NewGetUsageDetailsOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 			)
 
 			usage, response, err := mqcloudService.GetUsageDetails(getUsageDetailsOptions)
@@ -127,7 +128,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_options
 
 			getOptionsOptions := mqcloudService.NewGetOptionsOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 			)
 
 			configurationOptions, response, err := mqcloudService.GetOptions(getOptionsOptions)
@@ -149,11 +150,12 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-create_queue_manager
 
 			createQueueManagerOptions := mqcloudService.NewCreateQueueManagerOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				"testqm",
 				config["LOCATION"],
 				"xsmall",
 			)
+			createQueueManagerOptions.SetVersion(config["VERSION"])
 
 			queueManagerTaskStatus, response, err := mqcloudService.CreateQueueManager(createQueueManagerOptions)
 			if err != nil {
@@ -173,7 +175,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			fmt.Println("\nListQueueManagers() result:")
 			// begin-list_queue_managers
 			listQueueManagersOptions := &mqcloudv1.ListQueueManagersOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Limit:               core.Int64Ptr(int64(10)),
 			}
 
@@ -199,7 +201,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_queue_manager
 
 			getQueueManagerOptions := mqcloudService.NewGetQueueManagerOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 			)
 
@@ -218,12 +220,12 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 		})
 		It(`SetQueueManagerVersion request example`, func() {
 
-			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_GUID"])
+			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_DEPLOYMENT_GUID"])
 			fmt.Println("\nSetQueueManagerVersion() result:")
 			// begin-set_queue_manager_version
 
 			setQueueManagerVersionOptions := mqcloudService.NewSetQueueManagerVersionOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 				config["VERSION_UPGRADE"],
 			)
@@ -246,7 +248,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_queue_manager_available_upgrade_versions
 
 			getQueueManagerAvailableUpgradeVersionsOptions := mqcloudService.NewGetQueueManagerAvailableUpgradeVersionsOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 			)
 
@@ -268,7 +270,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_queue_manager_connection_info
 
 			getQueueManagerConnectionInfoOptions := mqcloudService.NewGetQueueManagerConnectionInfoOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 			)
 
@@ -290,7 +292,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_queue_manager_status
 
 			getQueueManagerStatusOptions := mqcloudService.NewGetQueueManagerStatusOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 			)
 
@@ -311,7 +313,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			fmt.Println("\nListUsers() result:")
 			// begin-list_users
 			listUsersOptions := &mqcloudv1.ListUsersOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Limit:               core.Int64Ptr(int64(10)),
 			}
 
@@ -337,7 +339,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-create_user
 
 			createUserOptions := mqcloudService.NewCreateUserOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				"testuser@ibm.com",
 				"testuser",
 			)
@@ -361,7 +363,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_user
 
 			getUserOptions := mqcloudService.NewGetUserOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["USER_ID"],
 			)
 
@@ -382,7 +384,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			fmt.Println("\nListApplications() result:")
 			// begin-list_applications
 			listApplicationsOptions := &mqcloudv1.ListApplicationsOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Limit:               core.Int64Ptr(int64(10)),
 			}
 
@@ -408,7 +410,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-create_application
 
 			createApplicationOptions := mqcloudService.NewCreateApplicationOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				"test-app",
 			)
 
@@ -431,7 +433,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_application
 
 			getApplicationOptions := mqcloudService.NewGetApplicationOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["APPLICATION_ID"],
 			)
 
@@ -453,7 +455,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-create_application_apikey
 
 			createApplicationApikeyOptions := mqcloudService.NewCreateApplicationApikeyOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["APPLICATION_ID"],
 				"test-api-key",
 			)
@@ -473,7 +475,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 		})
 		It(`CreateTrustStorePemCertificate request example`, func() {
 
-			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_GUID"])
+			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_DEPLOYMENT_GUID"])
 			fmt.Println("\nCreateTrustStorePemCertificate() result:")
 			// begin-create_trust_store_pem_certificate
 			file, err := os.Open(config["TRUST_STORE_FILE_PATH"])
@@ -484,7 +486,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			defer file.Close()
 
 			createTrustStorePemCertificateOptions := mqcloudService.NewCreateTrustStorePemCertificateOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 				"truststore",
 				file,
@@ -497,7 +499,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			config["TRUST_STORE_CERTIFICATE_ID"] = *trustStoreCertificateDetails.ID
 			b, _ := json.MarshalIndent(trustStoreCertificateDetails, "", "  ")
 			fmt.Println(string(b))
-
+			time.Sleep(30 * time.Second) // Add sleep for cert to upload and apply to qm and be available during delete
 			// end-create_trust_store_pem_certificate
 
 			Expect(err).To(BeNil())
@@ -509,7 +511,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-list_trust_store_certificates
 
 			listTrustStoreCertificatesOptions := mqcloudService.NewListTrustStoreCertificatesOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 			)
 
@@ -531,7 +533,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_trust_store_certificate
 
 			getTrustStoreCertificateOptions := mqcloudService.NewGetTrustStoreCertificateOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 				config["TRUST_STORE_CERTIFICATE_ID"],
 			)
@@ -554,7 +556,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-download_trust_store_certificate
 
 			downloadTrustStoreCertificateOptions := mqcloudService.NewDownloadTrustStoreCertificateOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 				config["TRUST_STORE_CERTIFICATE_ID"],
 			)
@@ -584,7 +586,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 		})
 		It(`CreateKeyStorePemCertificate request example`, func() {
 
-			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_GUID"])
+			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_DEPLOYMENT_GUID"])
 			fmt.Println("\nCreateKeyStorePemCertificate() result:")
 			// begin-create_key_store_pem_certificate
 			file, err := os.Open(config["KEY_STORE_FILE_PATH"])
@@ -594,12 +596,11 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			}
 			defer file.Close()
 			createKeyStorePemCertificateOptions := mqcloudService.NewCreateKeyStorePemCertificateOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 				"keystore",
 				file,
 			)
-
 			keyStoreCertificateDetails, response, err := mqcloudService.CreateKeyStorePemCertificate(createKeyStorePemCertificateOptions)
 			if err != nil {
 				panic(err)
@@ -607,7 +608,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			config["KEY_STORE_CERTIFICATE_ID"] = *keyStoreCertificateDetails.ID
 			b, _ := json.MarshalIndent(keyStoreCertificateDetails, "", "  ")
 			fmt.Println(string(b))
-
+			time.Sleep(30 * time.Second) // Add sleep for cert to upload and apply to qm and be available during delete
 			// end-create_key_store_pem_certificate
 
 			Expect(err).To(BeNil())
@@ -619,7 +620,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-list_key_store_certificates
 
 			listKeyStoreCertificatesOptions := mqcloudService.NewListKeyStoreCertificatesOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 			)
 
@@ -641,7 +642,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-get_key_store_certificate
 
 			getKeyStoreCertificateOptions := mqcloudService.NewGetKeyStoreCertificateOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 				config["KEY_STORE_CERTIFICATE_ID"],
 			)
@@ -664,7 +665,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-download_key_store_certificate
 
 			downloadKeyStoreCertificateOptions := mqcloudService.NewDownloadKeyStoreCertificateOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 				config["KEY_STORE_CERTIFICATE_ID"],
 			)
@@ -699,7 +700,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			getCertificateAmsChannelsOptions := mqcloudService.NewGetCertificateAmsChannelsOptions(
 				config["QUEUE_MANAGER_ID"],
 				config["KEY_STORE_CERTIFICATE_ID"],
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 			)
 
 			channelsDetails, response, err := mqcloudService.GetCertificateAmsChannels(getCertificateAmsChannelsOptions)
@@ -719,12 +720,17 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			fmt.Println("\nSetCertificateAmsChannels() result:")
 			// begin-set_certificate_ams_channels
 
+			// Construct an instance of the ChannelDetails model
+			channelDetailsModel := new(mqcloudv1.ChannelDetails)
+			channelDetailsModel.Name = core.StringPtr("testString")
+
 			setCertificateAmsChannelsOptions := mqcloudService.NewSetCertificateAmsChannelsOptions(
 				config["QUEUE_MANAGER_ID"],
 				config["KEY_STORE_CERTIFICATE_ID"],
-				config["SERVICE_INSTANCE_GUID"],
-				[]mqcloudv1.ChannelDetails{},
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
+				[]mqcloudv1.ChannelDetails{*channelDetailsModel},
 			)
+
 			setCertificateAmsChannelsOptions.UpdateStrategy = core.StringPtr("replace")
 
 			channelsDetails, response, err := mqcloudService.SetCertificateAmsChannels(setCertificateAmsChannelsOptions)
@@ -740,11 +746,105 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(channelsDetails).ToNot(BeNil())
 		})
+		It(`CreateVirtualPrivateEndpointGateway request example`, func() {
+			fmt.Println("\nCreateVirtualPrivateEndpointGateway() result:")
+			// begin-create_virtual_private_endpoint_gateway
+
+			createVirtualPrivateEndpointGatewayOptions := mqcloudService.NewCreateVirtualPrivateEndpointGatewayOptions(
+				config["SERVICE_INSTANCE_CAPACITY_GUID"],
+				"vpe_gateway1-to-vpe_gateway2",
+				config["TARGET_CRN"],
+			)
+			createVirtualPrivateEndpointGatewayOptions.SetTrustedProfile(config["TRUSTED_PROFILE"])
+
+			virtualPrivateEndpointGatewayDetails, response, err := mqcloudService.CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(virtualPrivateEndpointGatewayDetails, "", "  ")
+			fmt.Println(string(b))
+			config["VIRTUAL_PRIVATE_ENDPOINT_GATEWAY_GUID"] = *virtualPrivateEndpointGatewayDetails.ID
+			// end-create_virtual_private_endpoint_gateway
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(201))
+			Expect(virtualPrivateEndpointGatewayDetails).ToNot(BeNil())
+		})
+		It(`ListVirtualPrivateEndpointGateways request example`, func() {
+			fmt.Println("\nListVirtualPrivateEndpointGateways() result:")
+			// begin-list_virtual_private_endpoint_gateways
+			listVirtualPrivateEndpointGatewaysOptions := &mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions{
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_CAPACITY_GUID"]),
+				TrustedProfile:      core.StringPtr(config["TRUSTED_PROFILE"]),
+				Limit:               core.Int64Ptr(int64(10)),
+			}
+
+			pager, err := mqcloudService.NewVirtualPrivateEndpointGatewaysPager(listVirtualPrivateEndpointGatewaysOptions)
+			if err != nil {
+				panic(err)
+			}
+
+			var allResults []mqcloudv1.VirtualPrivateEndpointGatewayDetails
+			for pager.HasNext() {
+				nextPage, err := pager.GetNext()
+				if err != nil {
+					panic(err)
+				}
+				allResults = append(allResults, nextPage...)
+			}
+			b, _ := json.MarshalIndent(allResults, "", "  ")
+			fmt.Println(string(b))
+			// end-list_virtual_private_endpoint_gateways
+		})
+		It(`GetVirtualPrivateEndpointGateway request example`, func() {
+			fmt.Println("\nGetVirtualPrivateEndpointGateway() result:")
+			// begin-get_virtual_private_endpoint_gateway
+
+			getVirtualPrivateEndpointGatewayOptions := mqcloudService.NewGetVirtualPrivateEndpointGatewayOptions(
+				config["SERVICE_INSTANCE_CAPACITY_GUID"],
+				config["VIRTUAL_PRIVATE_ENDPOINT_GATEWAY_GUID"],
+			)
+			getVirtualPrivateEndpointGatewayOptions.SetTrustedProfile(config["TRUSTED_PROFILE"])
+			virtualPrivateEndpointGatewayDetails, response, err := mqcloudService.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(virtualPrivateEndpointGatewayDetails, "", "  ")
+			fmt.Println(string(b))
+
+			// end-get_virtual_private_endpoint_gateway
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(virtualPrivateEndpointGatewayDetails).ToNot(BeNil())
+		})
+		It(`DeleteVirtualPrivateEndpointGateway request example`, func() {
+			// begin-delete_virtual_private_endpoint_gateway
+
+			deleteVirtualPrivateEndpointGatewayOptions := mqcloudService.NewDeleteVirtualPrivateEndpointGatewayOptions(
+				config["SERVICE_INSTANCE_CAPACITY_GUID"],
+				config["VIRTUAL_PRIVATE_ENDPOINT_GATEWAY_GUID"],
+			)
+			deleteVirtualPrivateEndpointGatewayOptions.SetTrustedProfile(config["TRUSTED_PROFILE"])
+			response, err := mqcloudService.DeleteVirtualPrivateEndpointGateway(deleteVirtualPrivateEndpointGatewayOptions)
+			if err != nil {
+				panic(err)
+			}
+			if response.StatusCode != 204 {
+				fmt.Printf("\nUnexpected response status code received from DeleteVirtualPrivateEndpointGateway(): %d\n", response.StatusCode)
+			}
+
+			// end-delete_virtual_private_endpoint_gateway
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(204))
+		})
+
 		It(`DeleteUser request example`, func() {
 			// begin-delete_user
 
 			deleteUserOptions := mqcloudService.NewDeleteUserOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["USER_ID"],
 			)
 
@@ -765,7 +865,7 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-delete_application
 
 			deleteApplicationOptions := mqcloudService.NewDeleteApplicationOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["APPLICATION_ID"],
 			)
 
@@ -786,11 +886,10 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			// begin-delete_trust_store_certificate
 
 			deleteTrustStoreCertificateOptions := mqcloudService.NewDeleteTrustStoreCertificateOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 				config["TRUST_STORE_CERTIFICATE_ID"],
 			)
-
 			response, err := mqcloudService.DeleteTrustStoreCertificate(deleteTrustStoreCertificateOptions)
 			if err != nil {
 				panic(err)
@@ -806,9 +905,8 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 		})
 		It(`DeleteKeyStoreCertificate request example`, func() {
 			// begin-delete_key_store_certificate
-
 			deleteKeyStoreCertificateOptions := mqcloudService.NewDeleteKeyStoreCertificateOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 				config["KEY_STORE_CERTIFICATE_ID"],
 			)
@@ -826,13 +924,12 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(204))
 		})
-
 		It(`DeleteQueueManager request example`, func() {
 			fmt.Println("\nDeleteQueueManager() result:")
 			// begin-delete_queue_manager
 
 			deleteQueueManagerOptions := mqcloudService.NewDeleteQueueManagerOptions(
-				config["SERVICE_INSTANCE_GUID"],
+				config["SERVICE_INSTANCE_DEPLOYMENT_GUID"],
 				config["QUEUE_MANAGER_ID"],
 			)
 
@@ -849,5 +946,6 @@ var _ = Describe(`MqcloudV1 Examples Tests`, func() {
 			Expect(response.StatusCode).To(Equal(202))
 			Expect(queueManagerTaskStatus).ToNot(BeNil())
 		})
+
 	})
 })

--- a/mqcloudv1/mqcloud_v1_integration_test.go
+++ b/mqcloudv1/mqcloud_v1_integration_test.go
@@ -97,7 +97,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`GetUsageDetails(getUsageDetailsOptions *GetUsageDetailsOptions)`, func() {
 			getUsageDetailsOptions := &mqcloudv1.GetUsageDetailsOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 			}
 
 			usage, response, err := mqcloudService.GetUsageDetails(getUsageDetailsOptions)
@@ -113,7 +113,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`GetOptions(getOptionsOptions *GetOptionsOptions)`, func() {
 			getOptionsOptions := &mqcloudv1.GetOptionsOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 			}
 
 			configurationOptions, response, err := mqcloudService.GetOptions(getOptionsOptions)
@@ -130,8 +130,8 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`CreateQueueManager(createQueueManagerOptions *CreateQueueManagerOptions)`, func() {
 			createQueueManagerOptions := &mqcloudv1.CreateQueueManagerOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
-				Name:                core.StringPtr("testqm"),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
+				Name:                core.StringPtr("testqm10"),
 				Location:            core.StringPtr(config["LOCATION"]),
 				Size:                core.StringPtr("xsmall"),
 				DisplayName:         core.StringPtr("A test queue manager"),
@@ -152,7 +152,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`ListQueueManagers(listQueueManagersOptions *ListQueueManagersOptions) with pagination`, func() {
 			listQueueManagersOptions := &mqcloudv1.ListQueueManagersOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Offset:              core.Int64Ptr(int64(0)),
 				Limit:               core.Int64Ptr(int64(10)),
 			}
@@ -179,7 +179,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`ListQueueManagers(listQueueManagersOptions *ListQueueManagersOptions) using QueueManagersPager`, func() {
 			listQueueManagersOptions := &mqcloudv1.ListQueueManagersOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Limit:               core.Int64Ptr(int64(10)),
 			}
 
@@ -213,10 +213,11 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 	Describe(`GetQueueManager - Get details of a queue manager`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
+			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_DEPLOYMENT_GUID"])
 		})
 		It(`GetQueueManager(getQueueManagerOptions *GetQueueManagerOptions)`, func() {
 			getQueueManagerOptions := &mqcloudv1.GetQueueManagerOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 			}
 
@@ -230,11 +231,11 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 	Describe(`SetQueueManagerVersion - Upgrade a queue manager`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
-			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_GUID"])
+			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_DEPLOYMENT_GUID"])
 		})
 		It(`SetQueueManagerVersion(setQueueManagerVersionOptions *SetQueueManagerVersionOptions)`, func() {
 			setQueueManagerVersionOptions := &mqcloudv1.SetQueueManagerVersionOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 				Version:             core.StringPtr(config["VERSION_UPGRADE"]),
 			}
@@ -252,7 +253,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`GetQueueManagerAvailableUpgradeVersions(getQueueManagerAvailableUpgradeVersionsOptions *GetQueueManagerAvailableUpgradeVersionsOptions)`, func() {
 			getQueueManagerAvailableUpgradeVersionsOptions := &mqcloudv1.GetQueueManagerAvailableUpgradeVersionsOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 			}
 
@@ -269,7 +270,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`GetQueueManagerConnectionInfo(getQueueManagerConnectionInfoOptions *GetQueueManagerConnectionInfoOptions)`, func() {
 			getQueueManagerConnectionInfoOptions := &mqcloudv1.GetQueueManagerConnectionInfoOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 			}
 
@@ -286,7 +287,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`GetQueueManagerStatus(getQueueManagerStatusOptions *GetQueueManagerStatusOptions)`, func() {
 			getQueueManagerStatusOptions := &mqcloudv1.GetQueueManagerStatusOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 			}
 
@@ -303,7 +304,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`ListUsers(listUsersOptions *ListUsersOptions) with pagination`, func() {
 			listUsersOptions := &mqcloudv1.ListUsersOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Offset:              core.Int64Ptr(int64(0)),
 				Limit:               core.Int64Ptr(int64(10)),
 			}
@@ -330,7 +331,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`ListUsers(listUsersOptions *ListUsersOptions) using UsersPager`, func() {
 			listUsersOptions := &mqcloudv1.ListUsersOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Limit:               core.Int64Ptr(int64(10)),
 			}
 
@@ -367,7 +368,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`CreateUser(createUserOptions *CreateUserOptions)`, func() {
 			createUserOptions := &mqcloudv1.CreateUserOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Email:               core.StringPtr("testuser@ibm.com"),
 				Name:                core.StringPtr("testuser"),
 			}
@@ -386,7 +387,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`GetUser(getUserOptions *GetUserOptions)`, func() {
 			getUserOptions := &mqcloudv1.GetUserOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				UserID:              core.StringPtr(config["USER_ID"]),
 			}
 
@@ -403,7 +404,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`ListApplications(listApplicationsOptions *ListApplicationsOptions) with pagination`, func() {
 			listApplicationsOptions := &mqcloudv1.ListApplicationsOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Offset:              core.Int64Ptr(int64(0)),
 				Limit:               core.Int64Ptr(int64(10)),
 			}
@@ -428,9 +429,27 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 			}
 			fmt.Fprintf(GinkgoWriter, "Retrieved a total of %d item(s) with pagination.\n", len(allResults))
 		})
+		Describe(`CreateApplication - Add an application to an instance`, func() {
+			BeforeEach(func() {
+				shouldSkipTest()
+			})
+			It(`CreateApplication(createApplicationOptions *CreateApplicationOptions)`, func() {
+				createApplicationOptions := &mqcloudv1.CreateApplicationOptions{
+					ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
+					Name:                core.StringPtr("test-app"),
+				}
+
+				applicationCreated, response, err := mqcloudService.CreateApplication(createApplicationOptions)
+				Expect(err).To(BeNil())
+				config["APPLICATION_ID"] = *applicationCreated.ID
+				Expect(response.StatusCode).To(Equal(201))
+				Expect(applicationCreated).ToNot(BeNil())
+			})
+		})
+
 		It(`ListApplications(listApplicationsOptions *ListApplicationsOptions) using ApplicationsPager`, func() {
 			listApplicationsOptions := &mqcloudv1.ListApplicationsOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Limit:               core.Int64Ptr(int64(10)),
 			}
 
@@ -461,31 +480,13 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`CreateApplication - Add an application to an instance`, func() {
-		BeforeEach(func() {
-			shouldSkipTest()
-		})
-		It(`CreateApplication(createApplicationOptions *CreateApplicationOptions)`, func() {
-			createApplicationOptions := &mqcloudv1.CreateApplicationOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
-				Name:                core.StringPtr("test-app"),
-			}
-
-			applicationCreated, response, err := mqcloudService.CreateApplication(createApplicationOptions)
-			Expect(err).To(BeNil())
-			config["APPLICATION_ID"] = *applicationCreated.ID
-			Expect(response.StatusCode).To(Equal(201))
-			Expect(applicationCreated).ToNot(BeNil())
-		})
-	})
-
 	Describe(`GetApplication - Get an application for an instance`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
 		It(`GetApplication(getApplicationOptions *GetApplicationOptions)`, func() {
 			getApplicationOptions := &mqcloudv1.GetApplicationOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				ApplicationID:       core.StringPtr(config["APPLICATION_ID"]),
 			}
 
@@ -502,7 +503,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`CreateApplicationApikey(createApplicationApikeyOptions *CreateApplicationApikeyOptions)`, func() {
 			createApplicationApikeyOptions := &mqcloudv1.CreateApplicationApikeyOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				ApplicationID:       core.StringPtr(config["APPLICATION_ID"]),
 				Name:                core.StringPtr("test-api-key"),
 			}
@@ -517,7 +518,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 	Describe(`CreateTrustStorePemCertificate - Upload a trust store certificate`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
-			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_GUID"])
+			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_DEPLOYMENT_GUID"])
 
 		})
 		It(`CreateTrustStorePemCertificate(createTrustStorePemCertificateOptions *CreateTrustStorePemCertificateOptions)`, func() {
@@ -528,15 +529,16 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 			}
 			defer file.Close()
 			createTrustStorePemCertificateOptions := &mqcloudv1.CreateTrustStorePemCertificateOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
-				Label:               core.StringPtr("truststore"),
+				Label:               core.StringPtr("ittruststore"),
 				CertificateFile:     file,
 			}
 
 			trustStoreCertificateDetails, response, err := mqcloudService.CreateTrustStorePemCertificate(createTrustStorePemCertificateOptions)
 			Expect(err).To(BeNil())
 			config["TRUST_STORE_CERTIFICATE_ID"] = *trustStoreCertificateDetails.ID
+			time.Sleep(60 * time.Second)
 			Expect(response.StatusCode).To(Equal(201))
 			Expect(trustStoreCertificateDetails).ToNot(BeNil())
 		})
@@ -548,7 +550,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`ListTrustStoreCertificates(listTrustStoreCertificatesOptions *ListTrustStoreCertificatesOptions)`, func() {
 			listTrustStoreCertificatesOptions := &mqcloudv1.ListTrustStoreCertificatesOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 			}
 
@@ -565,7 +567,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`GetTrustStoreCertificate(getTrustStoreCertificateOptions *GetTrustStoreCertificateOptions)`, func() {
 			getTrustStoreCertificateOptions := &mqcloudv1.GetTrustStoreCertificateOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 				CertificateID:       core.StringPtr(config["TRUST_STORE_CERTIFICATE_ID"]),
 			}
@@ -583,7 +585,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`DownloadTrustStoreCertificate(downloadTrustStoreCertificateOptions *DownloadTrustStoreCertificateOptions)`, func() {
 			downloadTrustStoreCertificateOptions := &mqcloudv1.DownloadTrustStoreCertificateOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 				CertificateID:       core.StringPtr(config["TRUST_STORE_CERTIFICATE_ID"]),
 			}
@@ -598,7 +600,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 	Describe(`CreateKeyStorePemCertificate - Upload a key store certificate`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
-			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_GUID"])
+			SkipTestIfQmIsNotRunning(config["QUEUE_MANAGER_ID"], mqcloudService, config["SERVICE_INSTANCE_DEPLOYMENT_GUID"])
 		})
 		It(`CreateKeyStorePemCertificate(createKeyStorePemCertificateOptions *CreateKeyStorePemCertificateOptions)`, func() {
 			file, err := os.Open(config["KEY_STORE_FILE_PATH"])
@@ -608,15 +610,16 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 			}
 			defer file.Close()
 			createKeyStorePemCertificateOptions := &mqcloudv1.CreateKeyStorePemCertificateOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
-				Label:               core.StringPtr("keystore"),
+				Label:               core.StringPtr("itkeystore"),
 				CertificateFile:     file,
 			}
 
 			keyStoreCertificateDetails, response, err := mqcloudService.CreateKeyStorePemCertificate(createKeyStorePemCertificateOptions)
 			Expect(err).To(BeNil())
 			config["KEY_STORE_CERTIFICATE_ID"] = *keyStoreCertificateDetails.ID
+			time.Sleep(60 * time.Second)
 			Expect(response.StatusCode).To(Equal(201))
 			Expect(keyStoreCertificateDetails).ToNot(BeNil())
 		})
@@ -628,7 +631,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`ListKeyStoreCertificates(listKeyStoreCertificatesOptions *ListKeyStoreCertificatesOptions)`, func() {
 			listKeyStoreCertificatesOptions := &mqcloudv1.ListKeyStoreCertificatesOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 			}
 
@@ -645,7 +648,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`GetKeyStoreCertificate(getKeyStoreCertificateOptions *GetKeyStoreCertificateOptions)`, func() {
 			getKeyStoreCertificateOptions := &mqcloudv1.GetKeyStoreCertificateOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 				CertificateID:       core.StringPtr(config["KEY_STORE_CERTIFICATE_ID"]),
 			}
@@ -663,7 +666,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`DownloadKeyStoreCertificate(downloadKeyStoreCertificateOptions *DownloadKeyStoreCertificateOptions)`, func() {
 			downloadKeyStoreCertificateOptions := &mqcloudv1.DownloadKeyStoreCertificateOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 				CertificateID:       core.StringPtr(config["KEY_STORE_CERTIFICATE_ID"]),
 			}
@@ -683,7 +686,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 			getCertificateAmsChannelsOptions := &mqcloudv1.GetCertificateAmsChannelsOptions{
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 				CertificateID:       core.StringPtr(config["KEY_STORE_CERTIFICATE_ID"]),
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 			}
 
 			channelsDetails, response, err := mqcloudService.GetCertificateAmsChannels(getCertificateAmsChannelsOptions)
@@ -705,7 +708,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 			setCertificateAmsChannelsOptions := &mqcloudv1.SetCertificateAmsChannelsOptions{
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 				CertificateID:       core.StringPtr(config["KEY_STORE_CERTIFICATE_ID"]),
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				Channels:            []mqcloudv1.ChannelDetails{*channelDetailsModel},
 				UpdateStrategy:      core.StringPtr("append"),
 			}
@@ -725,13 +728,127 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 	})
 
+	Describe(`CreateVirtualPrivateEndpointGateway - Create a new virtual private endpoint gateway`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptions *CreateVirtualPrivateEndpointGatewayOptions)`, func() {
+			createVirtualPrivateEndpointGatewayOptions := &mqcloudv1.CreateVirtualPrivateEndpointGatewayOptions{
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_CAPACITY_GUID"]),
+				Name:                core.StringPtr("testvpegforit"),
+				TargetCrn:           core.StringPtr(config["TARGET_CRN"]),
+				TrustedProfile:      core.StringPtr(config["TRUSTED_PROFILE"]),
+			}
+
+			createVirtualPrivateEndpointGatewayOptions.TrustedProfile = nil
+			virtualPrivateEndpointGatewayDetails, response, err := mqcloudService.CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptions)
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(201))
+
+			Expect(virtualPrivateEndpointGatewayDetails).ToNot(BeNil())
+			gatewayid := *virtualPrivateEndpointGatewayDetails.ID
+			config["VIRTUAL_PRIVATE_ENDPOINT_GATEWAY_GUID"] = *virtualPrivateEndpointGatewayDetails.ID
+			Expect(gatewayid).To(Equal(config["VIRTUAL_PRIVATE_ENDPOINT_GATEWAY_GUID"]))
+		})
+	})
+
+	Describe(`ListVirtualPrivateEndpointGateways - Get a list of information for all virtual private endpoint gateways`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptions *ListVirtualPrivateEndpointGatewaysOptions) with pagination`, func() {
+			listVirtualPrivateEndpointGatewaysOptions := &mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions{
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_CAPACITY_GUID"]),
+				TrustedProfile:      core.StringPtr(config["TRUSTED_PROFILE"]),
+				Start:               core.StringPtr(""),
+				Limit:               core.Int64Ptr(int64(10)),
+			}
+
+			listVirtualPrivateEndpointGatewaysOptions.TrustedProfile = nil
+			listVirtualPrivateEndpointGatewaysOptions.Start = nil
+			listVirtualPrivateEndpointGatewaysOptions.Limit = core.Int64Ptr(1)
+
+			var allResults []mqcloudv1.VirtualPrivateEndpointGatewayDetails
+			for {
+
+				virtualPrivateEndpointGatewayDetailsCollection, response, err := mqcloudService.ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptions)
+
+				Expect(err).To(BeNil())
+				Expect(response.StatusCode).To(Equal(200))
+				Expect(virtualPrivateEndpointGatewayDetailsCollection).ToNot(BeNil())
+				allResults = append(allResults, virtualPrivateEndpointGatewayDetailsCollection.VirtualPrivateEndpointGateways...)
+
+				listVirtualPrivateEndpointGatewaysOptions.Start, err = virtualPrivateEndpointGatewayDetailsCollection.GetNextStart()
+				Expect(err).To(BeNil())
+				if listVirtualPrivateEndpointGatewaysOptions.Start == nil {
+
+					break
+				}
+				fmt.Println("START=" + *listVirtualPrivateEndpointGatewaysOptions.Start)
+			}
+			fmt.Fprintf(GinkgoWriter, "Retrieved a total of %d item(s) with pagination.\n", len(allResults))
+		})
+		It(`ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptions *ListVirtualPrivateEndpointGatewaysOptions) using VirtualPrivateEndpointGatewaysPager`, func() {
+			listVirtualPrivateEndpointGatewaysOptions := &mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions{
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_CAPACITY_GUID"]),
+				TrustedProfile:      core.StringPtr(config["TRUSTED_PROFILE"]),
+				Limit:               core.Int64Ptr(int64(10)),
+			}
+
+			// Test GetNext().
+			listVirtualPrivateEndpointGatewaysOptions.TrustedProfile = nil
+			pager, err := mqcloudService.NewVirtualPrivateEndpointGatewaysPager(listVirtualPrivateEndpointGatewaysOptions)
+			Expect(err).To(BeNil())
+			Expect(pager).ToNot(BeNil())
+
+			var allResults []mqcloudv1.VirtualPrivateEndpointGatewayDetails
+			for pager.HasNext() {
+				nextPage, err := pager.GetNext()
+				Expect(err).To(BeNil())
+				Expect(nextPage).ToNot(BeNil())
+				allResults = append(allResults, nextPage...)
+			}
+
+			// Test GetAll().
+			pager, err = mqcloudService.NewVirtualPrivateEndpointGatewaysPager(listVirtualPrivateEndpointGatewaysOptions)
+			Expect(err).To(BeNil())
+			Expect(pager).ToNot(BeNil())
+
+			allItems, err := pager.GetAll()
+			Expect(err).To(BeNil())
+			//		Expect(allItems).ToNot(BeNil())
+
+			Expect(len(allItems)).To(Equal(len(allResults)))
+			fmt.Fprintf(GinkgoWriter, "ListVirtualPrivateEndpointGateways() returned a total of %d item(s) using VirtualPrivateEndpointGatewaysPager.\n", len(allResults))
+		})
+	})
+
+	Describe(`GetVirtualPrivateEndpointGateway - Display the information for a specific virtual private endpoint gateway`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptions *GetVirtualPrivateEndpointGatewayOptions)`, func() {
+			getVirtualPrivateEndpointGatewayOptions := &mqcloudv1.GetVirtualPrivateEndpointGatewayOptions{
+				ServiceInstanceGuid:               core.StringPtr(config["SERVICE_INSTANCE_CAPACITY_GUID"]),
+				VirtualPrivateEndpointGatewayGuid: core.StringPtr(config["VIRTUAL_PRIVATE_ENDPOINT_GATEWAY_GUID"]),
+				TrustedProfile:                    core.StringPtr(config["TRUSTED_PROFILE"]),
+			}
+
+			getVirtualPrivateEndpointGatewayOptions.TrustedProfile = nil
+			virtualPrivateEndpointGatewayDetails, response, err := mqcloudService.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptions)
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(virtualPrivateEndpointGatewayDetails).ToNot(BeNil())
+		})
+	})
+
 	Describe(`DeleteUser - Delete a user for an instance`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
 		It(`DeleteUser(deleteUserOptions *DeleteUserOptions)`, func() {
 			deleteUserOptions := &mqcloudv1.DeleteUserOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				UserID:              core.StringPtr(config["USER_ID"]),
 			}
 
@@ -747,7 +864,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`DeleteApplication(deleteApplicationOptions *DeleteApplicationOptions)`, func() {
 			deleteApplicationOptions := &mqcloudv1.DeleteApplicationOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				ApplicationID:       core.StringPtr(config["APPLICATION_ID"]),
 			}
 
@@ -763,7 +880,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`DeleteTrustStoreCertificate(deleteTrustStoreCertificateOptions *DeleteTrustStoreCertificateOptions)`, func() {
 			deleteTrustStoreCertificateOptions := &mqcloudv1.DeleteTrustStoreCertificateOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 				CertificateID:       core.StringPtr(config["TRUST_STORE_CERTIFICATE_ID"]),
 			}
@@ -780,7 +897,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`DeleteKeyStoreCertificate(deleteKeyStoreCertificateOptions *DeleteKeyStoreCertificateOptions)`, func() {
 			deleteKeyStoreCertificateOptions := &mqcloudv1.DeleteKeyStoreCertificateOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 				CertificateID:       core.StringPtr(config["KEY_STORE_CERTIFICATE_ID"]),
 			}
@@ -797,7 +914,7 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 		})
 		It(`DeleteQueueManager(deleteQueueManagerOptions *DeleteQueueManagerOptions)`, func() {
 			deleteQueueManagerOptions := &mqcloudv1.DeleteQueueManagerOptions{
-				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_GUID"]),
+				ServiceInstanceGuid: core.StringPtr(config["SERVICE_INSTANCE_DEPLOYMENT_GUID"]),
 				QueueManagerID:      core.StringPtr(config["QUEUE_MANAGER_ID"]),
 			}
 
@@ -805,6 +922,23 @@ var _ = Describe(`MqcloudV1 Integration Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(202))
 			Expect(queueManagerTaskStatus).ToNot(BeNil())
+		})
+	})
+
+	Describe(`DeleteVirtualPrivateEndpointGateway - Delete a specific virtual private endpoint gateway`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`DeleteVirtualPrivateEndpointGateway(deleteVirtualPrivateEndpointGatewayOptions *DeleteVirtualPrivateEndpointGatewayOptions)`, func() {
+			deleteVirtualPrivateEndpointGatewayOptions := &mqcloudv1.DeleteVirtualPrivateEndpointGatewayOptions{
+				ServiceInstanceGuid:               core.StringPtr(config["SERVICE_INSTANCE_CAPACITY_GUID"]),
+				VirtualPrivateEndpointGatewayGuid: core.StringPtr(config["VIRTUAL_PRIVATE_ENDPOINT_GATEWAY_GUID"]),
+				TrustedProfile:                    core.StringPtr(config["TRUSTED_PROFILE"]),
+			}
+			deleteVirtualPrivateEndpointGatewayOptions.TrustedProfile = nil
+			response, err := mqcloudService.DeleteVirtualPrivateEndpointGateway(deleteVirtualPrivateEndpointGatewayOptions)
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(204))
 		})
 	})
 })

--- a/mqcloudv1/mqcloud_v1_test.go
+++ b/mqcloudv1/mqcloud_v1_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -7268,6 +7269,961 @@ var _ = Describe(`MqcloudV1`, func() {
 			})
 		})
 	})
+	Describe(`CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptions *CreateVirtualPrivateEndpointGatewayOptions) - Operation response error`, func() {
+		acceptLanguage := "en-US,en;q=0.5"
+		createVirtualPrivateEndpointGatewayPath := "/v1/a2b4d4bc-dadb-4637-bcec-9b7d1e723af8/virtual_private_endpoint_gateway"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createVirtualPrivateEndpointGatewayPath))
+					Expect(req.Method).To(Equal("POST"))
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateVirtualPrivateEndpointGateway with error: Operation response processing error`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the CreateVirtualPrivateEndpointGatewayOptions model
+				createVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.CreateVirtualPrivateEndpointGatewayOptions)
+				createVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				createVirtualPrivateEndpointGatewayOptionsModel.Name = core.StringPtr("vpe_gateway1-to-vpe_gateway2")
+				createVirtualPrivateEndpointGatewayOptionsModel.TargetCrn = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := mqcloudService.CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				mqcloudService.EnableRetries(0, 0)
+				result, response, operationErr = mqcloudService.CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptions *CreateVirtualPrivateEndpointGatewayOptions)`, func() {
+		acceptLanguage := "en-US,en;q=0.5"
+		createVirtualPrivateEndpointGatewayPath := "/v1/a2b4d4bc-dadb-4637-bcec-9b7d1e723af8/virtual_private_endpoint_gateway"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createVirtualPrivateEndpointGatewayPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"href": "Href", "id": "ID", "name": "Name", "target_crn": "TargetCrn", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke CreateVirtualPrivateEndpointGateway successfully with retries`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+				mqcloudService.EnableRetries(0, 0)
+
+				// Construct an instance of the CreateVirtualPrivateEndpointGatewayOptions model
+				createVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.CreateVirtualPrivateEndpointGatewayOptions)
+				createVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				createVirtualPrivateEndpointGatewayOptionsModel.Name = core.StringPtr("vpe_gateway1-to-vpe_gateway2")
+				createVirtualPrivateEndpointGatewayOptionsModel.TargetCrn = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := mqcloudService.CreateVirtualPrivateEndpointGatewayWithContext(ctx, createVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				mqcloudService.DisableRetries()
+				result, response, operationErr := mqcloudService.CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = mqcloudService.CreateVirtualPrivateEndpointGatewayWithContext(ctx, createVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createVirtualPrivateEndpointGatewayPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"href": "Href", "id": "ID", "name": "Name", "target_crn": "TargetCrn", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke CreateVirtualPrivateEndpointGateway successfully`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := mqcloudService.CreateVirtualPrivateEndpointGateway(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the CreateVirtualPrivateEndpointGatewayOptions model
+				createVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.CreateVirtualPrivateEndpointGatewayOptions)
+				createVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				createVirtualPrivateEndpointGatewayOptionsModel.Name = core.StringPtr("vpe_gateway1-to-vpe_gateway2")
+				createVirtualPrivateEndpointGatewayOptionsModel.TargetCrn = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = mqcloudService.CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke CreateVirtualPrivateEndpointGateway with error: Operation validation and request error`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the CreateVirtualPrivateEndpointGatewayOptions model
+				createVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.CreateVirtualPrivateEndpointGatewayOptions)
+				createVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				createVirtualPrivateEndpointGatewayOptionsModel.Name = core.StringPtr("vpe_gateway1-to-vpe_gateway2")
+				createVirtualPrivateEndpointGatewayOptionsModel.TargetCrn = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := mqcloudService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := mqcloudService.CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the CreateVirtualPrivateEndpointGatewayOptions model with no property values
+				createVirtualPrivateEndpointGatewayOptionsModelNew := new(mqcloudv1.CreateVirtualPrivateEndpointGatewayOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = mqcloudService.CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(201)
+				}))
+			})
+			It(`Invoke CreateVirtualPrivateEndpointGateway successfully`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the CreateVirtualPrivateEndpointGatewayOptions model
+				createVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.CreateVirtualPrivateEndpointGatewayOptions)
+				createVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				createVirtualPrivateEndpointGatewayOptionsModel.Name = core.StringPtr("vpe_gateway1-to-vpe_gateway2")
+				createVirtualPrivateEndpointGatewayOptionsModel.TargetCrn = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := mqcloudService.CreateVirtualPrivateEndpointGateway(createVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptions *ListVirtualPrivateEndpointGatewaysOptions) - Operation response error`, func() {
+		acceptLanguage := "en-US,en;q=0.5"
+		listVirtualPrivateEndpointGatewaysPath := "/v1/a2b4d4bc-dadb-4637-bcec-9b7d1e723af8/virtual_private_endpoint_gateway"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVirtualPrivateEndpointGatewaysPath))
+					Expect(req.Method).To(Equal("GET"))
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					Expect(req.URL.Query()["start"]).To(Equal([]string{"r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke ListVirtualPrivateEndpointGateways with error: Operation response processing error`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the ListVirtualPrivateEndpointGatewaysOptions model
+				listVirtualPrivateEndpointGatewaysOptionsModel := new(mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions)
+				listVirtualPrivateEndpointGatewaysOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				listVirtualPrivateEndpointGatewaysOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Start = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Limit = core.Int64Ptr(int64(10))
+				listVirtualPrivateEndpointGatewaysOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := mqcloudService.ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				mqcloudService.EnableRetries(0, 0)
+				result, response, operationErr = mqcloudService.ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptions *ListVirtualPrivateEndpointGatewaysOptions)`, func() {
+		acceptLanguage := "en-US,en;q=0.5"
+		listVirtualPrivateEndpointGatewaysPath := "/v1/a2b4d4bc-dadb-4637-bcec-9b7d1e723af8/virtual_private_endpoint_gateway"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVirtualPrivateEndpointGatewaysPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					Expect(req.URL.Query()["start"]).To(Equal([]string{"r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"limit": 50, "first": {"href": "Href"}, "next": {"href": "Href"}, "virtual_private_endpoint_gateways": [{"href": "Href", "id": "ID", "name": "Name", "target_crn": "TargetCrn", "status": "Status"}]}`)
+				}))
+			})
+			It(`Invoke ListVirtualPrivateEndpointGateways successfully with retries`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+				mqcloudService.EnableRetries(0, 0)
+
+				// Construct an instance of the ListVirtualPrivateEndpointGatewaysOptions model
+				listVirtualPrivateEndpointGatewaysOptionsModel := new(mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions)
+				listVirtualPrivateEndpointGatewaysOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				listVirtualPrivateEndpointGatewaysOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Start = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Limit = core.Int64Ptr(int64(10))
+				listVirtualPrivateEndpointGatewaysOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := mqcloudService.ListVirtualPrivateEndpointGatewaysWithContext(ctx, listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				mqcloudService.DisableRetries()
+				result, response, operationErr := mqcloudService.ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = mqcloudService.ListVirtualPrivateEndpointGatewaysWithContext(ctx, listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVirtualPrivateEndpointGatewaysPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					Expect(req.URL.Query()["start"]).To(Equal([]string{"r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"limit": 50, "first": {"href": "Href"}, "next": {"href": "Href"}, "virtual_private_endpoint_gateways": [{"href": "Href", "id": "ID", "name": "Name", "target_crn": "TargetCrn", "status": "Status"}]}`)
+				}))
+			})
+			It(`Invoke ListVirtualPrivateEndpointGateways successfully`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := mqcloudService.ListVirtualPrivateEndpointGateways(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ListVirtualPrivateEndpointGatewaysOptions model
+				listVirtualPrivateEndpointGatewaysOptionsModel := new(mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions)
+				listVirtualPrivateEndpointGatewaysOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				listVirtualPrivateEndpointGatewaysOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Start = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Limit = core.Int64Ptr(int64(10))
+				listVirtualPrivateEndpointGatewaysOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = mqcloudService.ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke ListVirtualPrivateEndpointGateways with error: Operation validation and request error`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the ListVirtualPrivateEndpointGatewaysOptions model
+				listVirtualPrivateEndpointGatewaysOptionsModel := new(mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions)
+				listVirtualPrivateEndpointGatewaysOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				listVirtualPrivateEndpointGatewaysOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Start = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Limit = core.Int64Ptr(int64(10))
+				listVirtualPrivateEndpointGatewaysOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := mqcloudService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := mqcloudService.ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the ListVirtualPrivateEndpointGatewaysOptions model with no property values
+				listVirtualPrivateEndpointGatewaysOptionsModelNew := new(mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = mqcloudService.ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke ListVirtualPrivateEndpointGateways successfully`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the ListVirtualPrivateEndpointGatewaysOptions model
+				listVirtualPrivateEndpointGatewaysOptionsModel := new(mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions)
+				listVirtualPrivateEndpointGatewaysOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				listVirtualPrivateEndpointGatewaysOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Start = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				listVirtualPrivateEndpointGatewaysOptionsModel.Limit = core.Int64Ptr(int64(10))
+				listVirtualPrivateEndpointGatewaysOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := mqcloudService.ListVirtualPrivateEndpointGateways(listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Test pagination helper method on response`, func() {
+			It(`Invoke GetNextStart successfully`, func() {
+				responseObject := new(mqcloudv1.VirtualPrivateEndpointGatewayDetailsCollection)
+				nextObject := new(mqcloudv1.Next)
+				nextObject.Href = core.StringPtr("ibm.com?start=abc-123")
+				responseObject.Next = nextObject
+
+				value, err := responseObject.GetNextStart()
+				Expect(err).To(BeNil())
+				Expect(value).To(Equal(core.StringPtr("abc-123")))
+			})
+			It(`Invoke GetNextStart without a "Next" property in the response`, func() {
+				responseObject := new(mqcloudv1.VirtualPrivateEndpointGatewayDetailsCollection)
+
+				value, err := responseObject.GetNextStart()
+				Expect(err).To(BeNil())
+				Expect(value).To(BeNil())
+			})
+			It(`Invoke GetNextStart without any query params in the "Next" URL`, func() {
+				responseObject := new(mqcloudv1.VirtualPrivateEndpointGatewayDetailsCollection)
+				nextObject := new(mqcloudv1.Next)
+				nextObject.Href = core.StringPtr("ibm.com")
+				responseObject.Next = nextObject
+
+				value, err := responseObject.GetNextStart()
+				Expect(err).To(BeNil())
+				Expect(value).To(BeNil())
+			})
+		})
+		Context(`Using mock server endpoint - paginated response`, func() {
+			BeforeEach(func() {
+				var requestNumber int = 0
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVirtualPrivateEndpointGatewaysPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					requestNumber++
+					if requestNumber == 1 {
+						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?start=1"},"total_count":2,"limit":1,"virtual_private_endpoint_gateways":[{"href":"Href","id":"ID","name":"Name","target_crn":"TargetCrn","status":"Status"}]}`)
+					} else if requestNumber == 2 {
+						fmt.Fprintf(res, "%s", `{"total_count":2,"limit":1,"virtual_private_endpoint_gateways":[{"href":"Href","id":"ID","name":"Name","target_crn":"TargetCrn","status":"Status"}]}`)
+					} else {
+						res.WriteHeader(400)
+					}
+				}))
+			})
+			It(`Use VirtualPrivateEndpointGatewaysPager.GetNext successfully`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				listVirtualPrivateEndpointGatewaysOptionsModel := &mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions{
+					ServiceInstanceGuid: core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"),
+					TrustedProfile:      core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud"),
+					Limit:               core.Int64Ptr(int64(10)),
+				}
+
+				pager, err := mqcloudService.NewVirtualPrivateEndpointGatewaysPager(listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(err).To(BeNil())
+				Expect(pager).ToNot(BeNil())
+
+				var allResults []mqcloudv1.VirtualPrivateEndpointGatewayDetails
+				for pager.HasNext() {
+					nextPage, err := pager.GetNext()
+					Expect(err).To(BeNil())
+					Expect(nextPage).ToNot(BeNil())
+					allResults = append(allResults, nextPage...)
+				}
+				Expect(len(allResults)).To(Equal(2))
+			})
+			It(`Use VirtualPrivateEndpointGatewaysPager.GetAll successfully`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				listVirtualPrivateEndpointGatewaysOptionsModel := &mqcloudv1.ListVirtualPrivateEndpointGatewaysOptions{
+					ServiceInstanceGuid: core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"),
+					TrustedProfile:      core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud"),
+					Limit:               core.Int64Ptr(int64(10)),
+				}
+
+				pager, err := mqcloudService.NewVirtualPrivateEndpointGatewaysPager(listVirtualPrivateEndpointGatewaysOptionsModel)
+				Expect(err).To(BeNil())
+				Expect(pager).ToNot(BeNil())
+
+				allResults, err := pager.GetAll()
+				Expect(err).To(BeNil())
+				Expect(allResults).ToNot(BeNil())
+				Expect(len(allResults)).To(Equal(2))
+			})
+		})
+	})
+	Describe(`GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptions *GetVirtualPrivateEndpointGatewayOptions) - Operation response error`, func() {
+		acceptLanguage := "en-US,en;q=0.5"
+		getVirtualPrivateEndpointGatewayPath := "/v1/a2b4d4bc-dadb-4637-bcec-9b7d1e723af8/virtual_private_endpoint_gateway/r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getVirtualPrivateEndpointGatewayPath))
+					Expect(req.Method).To(Equal("GET"))
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetVirtualPrivateEndpointGateway with error: Operation response processing error`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the GetVirtualPrivateEndpointGatewayOptions model
+				getVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.GetVirtualPrivateEndpointGatewayOptions)
+				getVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				getVirtualPrivateEndpointGatewayOptionsModel.VirtualPrivateEndpointGatewayGuid = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				getVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				getVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := mqcloudService.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				mqcloudService.EnableRetries(0, 0)
+				result, response, operationErr = mqcloudService.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptions *GetVirtualPrivateEndpointGatewayOptions)`, func() {
+		acceptLanguage := "en-US,en;q=0.5"
+		getVirtualPrivateEndpointGatewayPath := "/v1/a2b4d4bc-dadb-4637-bcec-9b7d1e723af8/virtual_private_endpoint_gateway/r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getVirtualPrivateEndpointGatewayPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"href": "Href", "id": "ID", "name": "Name", "target_crn": "TargetCrn", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke GetVirtualPrivateEndpointGateway successfully with retries`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+				mqcloudService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetVirtualPrivateEndpointGatewayOptions model
+				getVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.GetVirtualPrivateEndpointGatewayOptions)
+				getVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				getVirtualPrivateEndpointGatewayOptionsModel.VirtualPrivateEndpointGatewayGuid = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				getVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				getVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := mqcloudService.GetVirtualPrivateEndpointGatewayWithContext(ctx, getVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				mqcloudService.DisableRetries()
+				result, response, operationErr := mqcloudService.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = mqcloudService.GetVirtualPrivateEndpointGatewayWithContext(ctx, getVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getVirtualPrivateEndpointGatewayPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"href": "Href", "id": "ID", "name": "Name", "target_crn": "TargetCrn", "status": "Status"}`)
+				}))
+			})
+			It(`Invoke GetVirtualPrivateEndpointGateway successfully`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := mqcloudService.GetVirtualPrivateEndpointGateway(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetVirtualPrivateEndpointGatewayOptions model
+				getVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.GetVirtualPrivateEndpointGatewayOptions)
+				getVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				getVirtualPrivateEndpointGatewayOptionsModel.VirtualPrivateEndpointGatewayGuid = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				getVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				getVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = mqcloudService.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetVirtualPrivateEndpointGateway with error: Operation validation and request error`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the GetVirtualPrivateEndpointGatewayOptions model
+				getVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.GetVirtualPrivateEndpointGatewayOptions)
+				getVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				getVirtualPrivateEndpointGatewayOptionsModel.VirtualPrivateEndpointGatewayGuid = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				getVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				getVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := mqcloudService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := mqcloudService.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the GetVirtualPrivateEndpointGatewayOptions model with no property values
+				getVirtualPrivateEndpointGatewayOptionsModelNew := new(mqcloudv1.GetVirtualPrivateEndpointGatewayOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = mqcloudService.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetVirtualPrivateEndpointGateway successfully`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the GetVirtualPrivateEndpointGatewayOptions model
+				getVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.GetVirtualPrivateEndpointGatewayOptions)
+				getVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				getVirtualPrivateEndpointGatewayOptionsModel.VirtualPrivateEndpointGatewayGuid = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				getVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				getVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := mqcloudService.GetVirtualPrivateEndpointGateway(getVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteVirtualPrivateEndpointGateway(deleteVirtualPrivateEndpointGatewayOptions *DeleteVirtualPrivateEndpointGatewayOptions)`, func() {
+		acceptLanguage := "en-US,en;q=0.5"
+		deleteVirtualPrivateEndpointGatewayPath := "/v1/a2b4d4bc-dadb-4637-bcec-9b7d1e723af8/virtual_private_endpoint_gateway/r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44"
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteVirtualPrivateEndpointGatewayPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "en-US,en;q=0.5")))
+					Expect(req.Header["Trusted-Profile"]).ToNot(BeNil())
+					Expect(req.Header["Trusted-Profile"][0]).To(Equal(fmt.Sprintf("%v", "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+					res.WriteHeader(204)
+				}))
+			})
+			It(`Invoke DeleteVirtualPrivateEndpointGateway successfully`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				response, operationErr := mqcloudService.DeleteVirtualPrivateEndpointGateway(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+
+				// Construct an instance of the DeleteVirtualPrivateEndpointGatewayOptions model
+				deleteVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.DeleteVirtualPrivateEndpointGatewayOptions)
+				deleteVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				deleteVirtualPrivateEndpointGatewayOptionsModel.VirtualPrivateEndpointGatewayGuid = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				deleteVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				deleteVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				response, operationErr = mqcloudService.DeleteVirtualPrivateEndpointGateway(deleteVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+			})
+			It(`Invoke DeleteVirtualPrivateEndpointGateway with error: Operation validation and request error`, func() {
+				mqcloudService, serviceErr := mqcloudv1.NewMqcloudV1(&mqcloudv1.MqcloudV1Options{
+					URL:            testServer.URL,
+					Authenticator:  &core.NoAuthAuthenticator{},
+					AcceptLanguage: core.StringPtr(acceptLanguage),
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(mqcloudService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteVirtualPrivateEndpointGatewayOptions model
+				deleteVirtualPrivateEndpointGatewayOptionsModel := new(mqcloudv1.DeleteVirtualPrivateEndpointGatewayOptions)
+				deleteVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid = core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				deleteVirtualPrivateEndpointGatewayOptionsModel.VirtualPrivateEndpointGatewayGuid = core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				deleteVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile = core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				deleteVirtualPrivateEndpointGatewayOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := mqcloudService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				response, operationErr := mqcloudService.DeleteVirtualPrivateEndpointGateway(deleteVirtualPrivateEndpointGatewayOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				// Construct a second instance of the DeleteVirtualPrivateEndpointGatewayOptions model with no property values
+				deleteVirtualPrivateEndpointGatewayOptionsModelNew := new(mqcloudv1.DeleteVirtualPrivateEndpointGatewayOptions)
+				// Invoke operation with invalid model (negative test)
+				response, operationErr = mqcloudService.DeleteVirtualPrivateEndpointGateway(deleteVirtualPrivateEndpointGatewayOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`Model constructor tests`, func() {
 		Context(`Using a service client instance`, func() {
 			acceptLanguage := "en-US,en;q=0.5"
@@ -7382,6 +8338,24 @@ var _ = Describe(`MqcloudV1`, func() {
 				Expect(createUserOptionsModel.Name).To(Equal(core.StringPtr("testuser")))
 				Expect(createUserOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewCreateVirtualPrivateEndpointGatewayOptions successfully`, func() {
+				// Construct an instance of the CreateVirtualPrivateEndpointGatewayOptions model
+				serviceInstanceGuid := "a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"
+				createVirtualPrivateEndpointGatewayOptionsName := "vpe_gateway1-to-vpe_gateway2"
+				createVirtualPrivateEndpointGatewayOptionsTargetCrn := "crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud"
+				createVirtualPrivateEndpointGatewayOptionsModel := mqcloudService.NewCreateVirtualPrivateEndpointGatewayOptions(serviceInstanceGuid, createVirtualPrivateEndpointGatewayOptionsName, createVirtualPrivateEndpointGatewayOptionsTargetCrn)
+				createVirtualPrivateEndpointGatewayOptionsModel.SetServiceInstanceGuid("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				createVirtualPrivateEndpointGatewayOptionsModel.SetName("vpe_gateway1-to-vpe_gateway2")
+				createVirtualPrivateEndpointGatewayOptionsModel.SetTargetCrn("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.SetTrustedProfile("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				createVirtualPrivateEndpointGatewayOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(createVirtualPrivateEndpointGatewayOptionsModel).ToNot(BeNil())
+				Expect(createVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid).To(Equal(core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")))
+				Expect(createVirtualPrivateEndpointGatewayOptionsModel.Name).To(Equal(core.StringPtr("vpe_gateway1-to-vpe_gateway2")))
+				Expect(createVirtualPrivateEndpointGatewayOptionsModel.TargetCrn).To(Equal(core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+				Expect(createVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile).To(Equal(core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+				Expect(createVirtualPrivateEndpointGatewayOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewDeleteApplicationOptions successfully`, func() {
 				// Construct an instance of the DeleteApplicationOptions model
 				serviceInstanceGuid := "a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"
@@ -7452,6 +8426,21 @@ var _ = Describe(`MqcloudV1`, func() {
 				Expect(deleteUserOptionsModel.ServiceInstanceGuid).To(Equal(core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")))
 				Expect(deleteUserOptionsModel.UserID).To(Equal(core.StringPtr("31a413dd84346effc8895b6ba4641641")))
 				Expect(deleteUserOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewDeleteVirtualPrivateEndpointGatewayOptions successfully`, func() {
+				// Construct an instance of the DeleteVirtualPrivateEndpointGatewayOptions model
+				serviceInstanceGuid := "a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"
+				virtualPrivateEndpointGatewayGuid := "r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44"
+				deleteVirtualPrivateEndpointGatewayOptionsModel := mqcloudService.NewDeleteVirtualPrivateEndpointGatewayOptions(serviceInstanceGuid, virtualPrivateEndpointGatewayGuid)
+				deleteVirtualPrivateEndpointGatewayOptionsModel.SetServiceInstanceGuid("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				deleteVirtualPrivateEndpointGatewayOptionsModel.SetVirtualPrivateEndpointGatewayGuid("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				deleteVirtualPrivateEndpointGatewayOptionsModel.SetTrustedProfile("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				deleteVirtualPrivateEndpointGatewayOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(deleteVirtualPrivateEndpointGatewayOptionsModel).ToNot(BeNil())
+				Expect(deleteVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid).To(Equal(core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")))
+				Expect(deleteVirtualPrivateEndpointGatewayOptionsModel.VirtualPrivateEndpointGatewayGuid).To(Equal(core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")))
+				Expect(deleteVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile).To(Equal(core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+				Expect(deleteVirtualPrivateEndpointGatewayOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewDownloadKeyStoreCertificateOptions successfully`, func() {
 				// Construct an instance of the DownloadKeyStoreCertificateOptions model
@@ -7631,6 +8620,21 @@ var _ = Describe(`MqcloudV1`, func() {
 				Expect(getUserOptionsModel.UserID).To(Equal(core.StringPtr("31a413dd84346effc8895b6ba4641641")))
 				Expect(getUserOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewGetVirtualPrivateEndpointGatewayOptions successfully`, func() {
+				// Construct an instance of the GetVirtualPrivateEndpointGatewayOptions model
+				serviceInstanceGuid := "a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"
+				virtualPrivateEndpointGatewayGuid := "r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44"
+				getVirtualPrivateEndpointGatewayOptionsModel := mqcloudService.NewGetVirtualPrivateEndpointGatewayOptions(serviceInstanceGuid, virtualPrivateEndpointGatewayGuid)
+				getVirtualPrivateEndpointGatewayOptionsModel.SetServiceInstanceGuid("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				getVirtualPrivateEndpointGatewayOptionsModel.SetVirtualPrivateEndpointGatewayGuid("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				getVirtualPrivateEndpointGatewayOptionsModel.SetTrustedProfile("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				getVirtualPrivateEndpointGatewayOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getVirtualPrivateEndpointGatewayOptionsModel).ToNot(BeNil())
+				Expect(getVirtualPrivateEndpointGatewayOptionsModel.ServiceInstanceGuid).To(Equal(core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")))
+				Expect(getVirtualPrivateEndpointGatewayOptionsModel.VirtualPrivateEndpointGatewayGuid).To(Equal(core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")))
+				Expect(getVirtualPrivateEndpointGatewayOptionsModel.TrustedProfile).To(Equal(core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+				Expect(getVirtualPrivateEndpointGatewayOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewListApplicationsOptions successfully`, func() {
 				// Construct an instance of the ListApplicationsOptions model
 				serviceInstanceGuid := "a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"
@@ -7699,6 +8703,22 @@ var _ = Describe(`MqcloudV1`, func() {
 				Expect(listUsersOptionsModel.Limit).To(Equal(core.Int64Ptr(int64(10))))
 				Expect(listUsersOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewListVirtualPrivateEndpointGatewaysOptions successfully`, func() {
+				// Construct an instance of the ListVirtualPrivateEndpointGatewaysOptions model
+				serviceInstanceGuid := "a2b4d4bc-dadb-4637-bcec-9b7d1e723af8"
+				listVirtualPrivateEndpointGatewaysOptionsModel := mqcloudService.NewListVirtualPrivateEndpointGatewaysOptions(serviceInstanceGuid)
+				listVirtualPrivateEndpointGatewaysOptionsModel.SetServiceInstanceGuid("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")
+				listVirtualPrivateEndpointGatewaysOptionsModel.SetTrustedProfile("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")
+				listVirtualPrivateEndpointGatewaysOptionsModel.SetStart("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")
+				listVirtualPrivateEndpointGatewaysOptionsModel.SetLimit(int64(10))
+				listVirtualPrivateEndpointGatewaysOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(listVirtualPrivateEndpointGatewaysOptionsModel).ToNot(BeNil())
+				Expect(listVirtualPrivateEndpointGatewaysOptionsModel.ServiceInstanceGuid).To(Equal(core.StringPtr("a2b4d4bc-dadb-4637-bcec-9b7d1e723af8")))
+				Expect(listVirtualPrivateEndpointGatewaysOptionsModel.TrustedProfile).To(Equal(core.StringPtr("crn:v1:staging:public:mq-eude-stackname:eu-de:::endpoint:qm1.private.stackname.mq2.test.appdomain.cloud")))
+				Expect(listVirtualPrivateEndpointGatewaysOptionsModel.Start).To(Equal(core.StringPtr("r010-ebab3c08-c9a8-40c4-8869-61c09ddf7b44")))
+				Expect(listVirtualPrivateEndpointGatewaysOptionsModel.Limit).To(Equal(core.Int64Ptr(int64(10))))
+				Expect(listVirtualPrivateEndpointGatewaysOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewSetCertificateAmsChannelsOptions successfully`, func() {
 				// Construct an instance of the ChannelDetails model
 				channelDetailsModel := new(mqcloudv1.ChannelDetails)
@@ -7766,7 +8786,7 @@ var _ = Describe(`MqcloudV1`, func() {
 	})
 	Describe(`Utility function tests`, func() {
 		It(`Invoke CreateMockByteArray() successfully`, func() {
-			mockByteArray := CreateMockByteArray("This is a test")
+			mockByteArray := CreateMockByteArray("VGhpcyBpcyBhIHRlc3Qgb2YgdGhlIGVtZXJnZW5jeSBicm9hZGNhc3Qgc3lzdGVt")
 			Expect(mockByteArray).ToNot(BeNil())
 		})
 		It(`Invoke CreateMockUUID() successfully`, func() {
@@ -7792,8 +8812,11 @@ var _ = Describe(`MqcloudV1`, func() {
 // Utility functions used by the generated test code
 //
 
-func CreateMockByteArray(mockData string) *[]byte {
-	ba := []byte(mockData)
+func CreateMockByteArray(encodedString string) *[]byte {
+	ba, err := base64.StdEncoding.DecodeString(encodedString)
+	if err != nil {
+		panic(err)
+	}
 	return &ba
 }
 
@@ -7833,7 +8856,6 @@ func ClearTestEnvironment(testEnvironment map[string]string) {
 		os.Unsetenv(key)
 	}
 }
-
 func SkipTestIfQmIsNotRunning(queue_manager_id string, mqcloudService *mqcloudv1.MqcloudV1, service_instance_guid string) {
 	error := WaitForQmStatus(queue_manager_id, mqcloudService, service_instance_guid)
 	if error != nil {


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] All unit tests successfully pass.
- [ ] The config["<env-var-name>"] format is consistently used in both integration and examples tests, avoiding any hardcoded values for the environment variables
- [ ] Newly introduced environment variables are documented in the internal documentation.
- [ ] All Integration tests are passing. If not all tests run successfully in a single run, ensure each function passes when run individually.
- [ ] All Examples tests are passing. If not all tests run successfully in a single run, ensure each function passes when run individually.
- [ ] All Go files are formatted according to standards.
- [ ] The latest SDK template and SDK generator are being used.
- [ ] The build process completes without errors.

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  

## What is the new behavior?  

* Created following APIs.

* Create VPE API - This API needs to accept the source capacity plan and target capacity plan objects. A VPEG for the target CRN is created in the source VPC of the owning reserved capacity service instance. 

* List VPE API -  This API returns a list of target capacity plans & PPNLBs that the source capacity plan is connected to. Using GHoST to search using the applied labels could be used here.

* Get VPE API - Return details of a single VPE

* Delete VPE API- Delete the VPEGs from the VPCs.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->